### PR TITLE
add default log level for operator

### DIFF
--- a/keda/templates/operator.yaml
+++ b/keda/templates/operator.yaml
@@ -24,6 +24,8 @@ spec:
           image: "{{ .Values.image.keda }}"
           command:
           - keda
+          args:
+          - '--zap-level=info'
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
Adding default log level to deployment.yaml. So users can easily find the right place, in case they would need to change the log level.

Fixes https://github.com/kedacore/keda/issues/467