### PR TITLE
logging levels for Operator and Metrics Server

### DIFF
--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -40,10 +40,10 @@ spec:
             - name: WATCH_NAMESPACE
               value: ""
           args:
-            - /usr/local/bin/keda-adapter
-            - --secure-port=6443
-            - --logtostderr=true
-            - --v=0
+          - /usr/local/bin/keda-adapter
+          - --secure-port=6443
+          - --logtostderr=true
+          - --v={{ .Values.logLevelMetrics }}
           ports:
             - containerPort: {{ .Values.service.portHttpsTarget }}
               name: https

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -36,7 +36,15 @@ aadPodIdentity: ""
 # will be mounted to the /grpccerts path on the Pod
 grpcTLSCertsSecret: ""
 
+## Logging level for KEDA Controller 
+# allowed values: 'debug', 'info', 'error', or an integer value greater than 0, specified as string
+# default value: info
 logLevel: info
+
+## Logging level for Metrics Server
+# allowed values: '0' for info, '4' for debug, or an integer value greater than 0, specified as string
+# default value: 0
+logLevelMetrics: 0
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
* enables us to modify log level for Metrics Server
* documents possible log levels for both Operator and Metrics server

Related issue: https://github.com/kedacore/keda/issues/618