### PR TITLE
add option for users to insert labels on KEDA operator deployment

### DIFF
--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Values.operatorName }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{ tpl .Values.extraLabels . | indent 4}}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Values.operatorName }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-{{ tpl .Values.extraLabels . | indent 4}}
+{{ tpl .Values.additionalLabels . | indent 4}}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -14,6 +14,8 @@ watchNamespace: ""
 imagePullSecrets: []
 operatorName: keda-operator
 
+extraLabels: ""
+
 customResourceDefinition:
   create: true
 

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -14,7 +14,7 @@ watchNamespace: ""
 imagePullSecrets: []
 operatorName: keda-operator
 
-extraLabels: ""
+additionalLabels: ""
 
 customResourceDefinition:
   create: true


### PR DESCRIPTION
When creating networkPolicies across namespaces, it's useful to assign labels to the keda operator (the example here being that in the postgreSQL-scaler, we need to access a postgres service in a separate namespace).