### PR TITLE
Add priorityClassName to pods specs

### DIFF
--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -4,7 +4,7 @@ description: Event-based autoscaler for workloads on Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.1
+version: 1.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -29,9 +29,12 @@ spec:
         aadpodidbinding: {{ .Values.aadPodIdentity }}
         {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
-        imagePullSecrets:
-          {{- toYaml . | nindent 8 }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       securityContext:

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -27,9 +27,12 @@ spec:
         aadpodidbinding: {{ .Values.aadPodIdentity }}
         {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
-        imagePullSecrets:
-          {{- toYaml . | nindent 8 }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       securityContext:

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -86,3 +86,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+## Optional priorityClassName for KEDA Controller and Metrics Adapter
+priorityClassName: ""


### PR DESCRIPTION
Add the ability to define `priorityClassName` for KEDA and Metrics Adapter pods in `values.yaml`.