### PR TITLE
Move podAnnotations to deployment specs

### DIFF
--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -12,10 +12,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{ tpl .Values.additionalLabels . | indent 4}}
-  {{- if .Values.podAnnotations.keda }}
-  annotations:
-  {{ tpl .Values.podAnnotations.keda . | indent 4}}
-  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -28,6 +24,10 @@ spec:
         {{- if .Values.aadPodIdentity }}
         aadpodidbinding: {{ .Values.aadPodIdentity }}
         {{- end }}
+      {{- if .Values.podAnnotations.keda }}
+      annotations:
+      {{- tpl .Values.podAnnotations.keda . | nindent 8}}
+      {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -10,10 +10,6 @@ metadata:
     app.kubernetes.io/part-of: {{ .Values.operatorName }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if .Values.podAnnotations.metricsAdapter }}
-  annotations:
-  {{ tpl .Values.podAnnotations.metricsAdapter . | indent 4}}
-  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -26,6 +22,10 @@ spec:
         {{- if .Values.aadPodIdentity }}
         aadpodidbinding: {{ .Values.aadPodIdentity }}
         {{- end }}
+      {{- if .Values.podAnnotations.metricsAdapter }}
+      annotations:
+      {{- toYaml .Values.podAnnotations.metricsAdapter | nindent 8}}
+      {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}


### PR DESCRIPTION
After discussions in https://github.com/kedacore/charts/issues/35 and https://github.com/kedacore/keda/issues/706, this moves the podAnnotations to the correct place in deployment.spec.template