### PR TITLE
Adding the logTimeFormat value for time formatting in the KEDA Operator

### DIFF
--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -4,7 +4,7 @@ description: Event-based autoscaler for workloads on Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.3
+version: 1.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -4,7 +4,7 @@ description: Event-based autoscaler for workloads on Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.2
+version: 1.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -49,6 +49,7 @@ spec:
           - keda
           args:
           - "--zap-level={{ .Values.logLevel }}"
+          - "--zap-time-encoding={{ .Values.logTimeFormat }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: WATCH_NAMESPACE

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -52,6 +52,11 @@ grpcTLSCertsSecret: ""
 # default value: info
 logLevel: info
 
+## Logging time format for KEDA Controller
+# allowed values: 'epoch', 'millis', 'nano', or 'iso8601'
+# default value: epoch
+logTimeFormat: epoch
+
 ## Logging level for Metrics Server
 # allowed values: '0' for info, '4' for debug, or an integer value greater than 0, specified as string
 # default value: 0


### PR DESCRIPTION
This allows for adjusting the `zap-time-encoding` argument to the KEDA Operator so that time formats like ISO8601 can be used. ISO8601 is more reader-friendly when examining the timestamps in the logs and possibly could be used as the default value in the values.yaml.