### PR TITLE
Allow metric adapter to serve a single namespace

### DIFF
--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -4,7 +4,7 @@ description: Event-based autoscaler for workloads on Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.2
+version: 1.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: WATCH_NAMESPACE
-              value: ""
+              value: {{ .Values.watchNamespace }}
           args:
           - /usr/local/bin/keda-adapter
           - --secure-port=6443


### PR DESCRIPTION
Pass `WATCH_NAMESPACE` environment variable as a value to allow metric adapter to serve a single namespace.

Signed-off-by: amirschw <24677563+amirschw@users.noreply.github.com>