### PR TITLE
Remove instance count for KEDA workloads

### DIFF
--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{ tpl .Values.additionalLabels . | indent 4}}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: {{ .Values.operatorName }}

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: {{ .Values.operatorName }}-metrics-apiserver

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   keda: docker.io/kedacore/keda:1.4.1
   metricsAdapter: docker.io/kedacore/keda-metrics-adapter:1.4.1


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Remove instance count for KEDA workloads as we only support single-instance deployments.

Relates to #50