### PR TITLE
Fix podAnnotations for keda deployment

### DIFF
--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -4,11 +4,11 @@ description: Event-based autoscaler for workloads on Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.4.1
+version: 1.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.4.1
+appVersion: 1.4.2
 
 home: https://github.com/kedacore/keda
 icon: https://raw.githubusercontent.com/kedacore/keda/master/images/keda-logo-500x500-white.png

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- end }}
       {{- if .Values.podAnnotations.keda }}
       annotations:
-      {{- tpl .Values.podAnnotations.keda . | nindent 8}}
+      {{- toYaml .Values.podAnnotations.keda | nindent 8}}
       {{- end }}
     spec:
       {{- if .Values.priorityClassName }}


### PR DESCRIPTION
I've faced an issue with setting up kiam podAnnotation for keda deployment.

Got the following error:

```
Error: template: keda/templates/12-keda-deployment.yaml:30:21: executing "keda/templates/12-keda-deployment.yaml" at <.Values.podAnnotations.keda>: wrong type for value; expected string; got map[string]interface {}
```

For metricsAdapter everything worked as expected.

So replacing `tpl` function with `toYaml` must resolve the issue. 