### PR TITLE
Add serviceAccount.annotations to enable EKS IAM roles

### DIFF
--- a/keda/templates/01-serviceaccount.yaml
+++ b/keda/templates/01-serviceaccount.yaml
@@ -8,6 +8,10 @@ metadata:
     app.kubernetes.io/part-of: {{ .Values.operatorName }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+  {{- toYaml .Values.serviceAccount.annotations | nindent 6}}
+  {{- end }}
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -35,6 +35,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: keda-operator
+  # Annotations to add to the service account
+  annotations: {}
 
 # Set to the value of the Azure Active Directory Pod Identity
 # This will be set as a label on the Keda Pod(s)


### PR DESCRIPTION
Currently, the chart supports pod annotations which enables the kiam/kube2iam case. This adds the option of a serviceaccount annotation which enables the EKS service account IAM roles case, so that `identityOwner: operator` can be used successfully with EKS.