### PR TITLE
Use patched version of ScaledJob CRD

### DIFF
--- a/keda/crds/scaledjobs.keda.sh.yaml
+++ b/keda/crds/scaledjobs.keda.sh.yaml
@@ -1467,6 +1467,7 @@ spec:
                                         type: string
                                     required:
                                     - containerPort
+                                    - protocol
                                     type: object
                                   type: array
                                   x-kubernetes-list-map-keys:
@@ -2706,6 +2707,7 @@ spec:
                                         type: string
                                     required:
                                     - containerPort
+                                    - protocol
                                     type: object
                                   type: array
                                 readinessProbe:
@@ -3951,6 +3953,7 @@ spec:
                                         type: string
                                     required:
                                     - containerPort
+                                    - protocol
                                     type: object
                                   type: array
                                   x-kubernetes-list-map-keys:


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Use patched version of ScaledJob CRD.

Follow-up of https://github.com/kedacore/charts/pull/60.