### PR TITLE
Update images' tag (from beta to rc)

### DIFF
--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  keda: docker.io/kedacore/keda:2.0.0-beta
-  metricsApiServer: docker.io/kedacore/keda-metrics-apiserver:2.0.0-beta
+  keda: docker.io/kedacore/keda:2.0.0-rc
+  metricsApiServer: docker.io/kedacore/keda-metrics-apiserver:2.0.0-rc
   pullPolicy: Always
 
 watchNamespace: ""


### PR DESCRIPTION
The tags in the `values.yaml` were still those for the beta release. This PR updates the tags to be those of the RC release.

Signed-off-by: Maxence Boutet <mboutet@explorance.com>