### PR TITLE
Change cluster role binding name for metrics adapter

### DIFF
--- a/keda/templates/21-metrics-clusterrolebinding.yaml
+++ b/keda/templates/21-metrics-clusterrolebinding.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Values.operator.name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name}}
-  name: {{ .Values.operator.name }}:system:auth-delegator
+  name: {{ .Values.operator.name }}-system-auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Change cluster role binding name for metrics adapter to comply with Helm naming convention.