### PR TITLE
Use Helm charts's app version as default tag

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -56,15 +56,17 @@ their default values.
 
 | Parameter                              | Description                               | Default                                         |
 |:---------------------------------------|:------------------------------------------|:------------------------------------------------|
-| `image.keda`                           | Image name of KEDA operator               | `docker.io/kedacore/keda:2.0.0-beta`                 |
-| `image.metricsApiServer`                 | Image name of KEDA Metrics API Server        | `docker.io/kedacore/keda-metrics-apiserver:2.0.0-beta` |
+| `image.keda.repository`                | Image name of KEDA operator               | `docker.io/kedacore/keda`                 |
+| `image.keda.tag`                       | Image tag of KEDA operator. Optional, given app version of Helm chart is used by default | ``                 |
+| `image.metricsApiServer.repository`    | Image name of KEDA Metrics API Server        | `docker.io/kedacore/keda-metrics-apiserver` |
+| `image.metricsApiServer.tag`           | Image tag of KEDA Metrics API Server. Optional, given app version of Helm chart is used by default | ``                 |
 | `watchNamespace`                       | Policy to use to pull Docker images       | `` |
 | `operator.name`                        | Name of the KEDA operator | `keda-operator` |
 | `imagePullSecrets`                     | Name of secret to use to pull images to use to pull Docker images | `[]` |
 | `additionalLabels`                     | Additional labels to apply to KEDA workloads | `` |
 | `podAnnotations.keda`                  | Pod annotations for KEDA operator | `` |
 | `podAnnotations.metricsAdapter`        | Pod annotations for KEDA Metrics Adapter | `` |
-| `podDisruptionBudget`                  | Capability to configure [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)       | `{}`                                        |
+| `podDisruptionBudget`                  | Capability to configure [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)       | `{}` |
 | `customResourceDefinition.create`      | Specifies whether KEDA CRDs should be created | `true`                                        |
 | `rbac.create`                          | Specifies whether RBAC should be used | `true`                                        |
 | `serviceAccount.create`                | Specifies whether a service account should be created       | `true`                                        |
@@ -84,7 +86,6 @@ their default values.
 | `affinity`                             | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) | `{}` |
 | `priorityClassName`                    | Pod priority for KEDA Operator and Metrics Adapter ([docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)) | `` |
 | `env`                                  | Additional environment variables that will be passed onto KEDA operator and metrics api service | `` |
-| `service.type`                         | Service type for KEDA Metric Server | `ClusterIP`                                        |
 | `service.portHttp`                     | Service HTTP port for KEDA Metric Server service | `80`                                        |
 | `service.portHttpTarget`               | Service HTTP port for KEDA Metric Server container | `8080`                                        |
 | `service.portHttps`                    | HTTPS port for KEDA Metric Server service | `443`                                        |
@@ -95,7 +96,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to
 
 ```console
 $ helm install keda kedacore/keda --namespace keda \
-               --set image.keda='<image-name>'
+               --set service.portHttp='<http-port>'
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can

--- a/keda/README.md
+++ b/keda/README.md
@@ -96,7 +96,8 @@ Specify each parameter using the `--set key=value[,key=value]` argument to
 
 ```console
 $ helm install keda kedacore/keda --namespace keda \
-               --set service.portHttp='<http-port>'
+               --set image.keda.tag=<different tag from app version>
+               --set image.metricsApiServer.tag=<different tag from app version>
 ```
 
 Alternatively, a YAML file that specifies the values for the above parameters can

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -44,7 +44,7 @@ spec:
         - name: {{ .Values.operator.name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.keda }}"
+          image: "{{ .Values.image.keda.repository }}:{{ .Values.image.keda.tag | default .Chart.AppVersion }}"
           command:
           - "/keda"
           args:

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - name: {{ .Values.operator.name }}-metrics-apiserver
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.metricsApiServer }}"
+          image: "{{ .Values.image.metricsApiServer.repository }}:{{ .Values.image.metricsApiServer.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             httpGet:

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -3,8 +3,14 @@
 # Declare variables to be passed into your templates.
 
 image:
-  keda: docker.io/kedacore/keda:2.0.0-rc
-  metricsApiServer: docker.io/kedacore/keda-metrics-apiserver:2.0.0-rc
+  keda:
+    repository: docker.io/kedacore/keda
+    # Allows people to override tag if they don't want to use the app version
+    tag: 
+  metricsApiServer:
+    repository: docker.io/kedacore/keda-metrics-apiserver
+    # Allows people to override tag if they don't want to use the app version
+    tag:
   pullPolicy: Always
 
 watchNamespace: ""


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

### Default installation sample

```shell
tkerkhove@CLT-TKERKHOVE  C:\Code\GitHub\keda-charts   default-tag ↑1                                                                                                                                [07:17]
❯ helm template keda
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
---
# Source: keda/templates/12-keda-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: keda-operator
  namespace: platform-gateway-firmware-repository-dev
  labels:
    <redacted>

spec:
  replicas: 1
  selector:
    matchLabels:
      app: keda-operator
  template:
    metadata:
      labels:
        app: keda-operator
    spec:
      serviceAccountName: keda-operator
      securityContext:
        {}
      containers:
        - name: keda-operator
          securityContext:
            {}
          image: "docker.io/kedacore/keda:2.0.0-rc"
    <redacted>
---
# Source: keda/templates/22-metrics-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: keda-operator-metrics-apiserver
  namespace: platform-gateway-firmware-repository-dev
  labels:
    <redacted>
spec:
  replicas: 1
  selector:
    matchLabels:
      app: keda-operator-metrics-apiserver
  template:
    metadata:
      labels:
        app: keda-operator-metrics-apiserver
      annotations:
    spec:
      serviceAccountName: keda-operator
      securityContext:
        {}
      containers:
        - name: keda-operator-metrics-apiserver
          securityContext:
            {}
          image: "docker.io/kedacore/keda-metrics-apiserver:2.0.0-rc"
    <redacted>
```

### Specifically state tags sample

```shell
tkerkhove@CLT-TKERKHOVE  C:\Code\GitHub\keda-charts   default-tag ≣                                                                                                                                 [07:16]
❯ helm template keda --set image.keda.tag=1.2.3 --set image.metricsApiServer.tag=5.6.7
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
manifest_sorter.go:192: info: skipping unknown hook: "crd-install"
---
# Source: keda/templates/12-keda-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: keda-operator
  namespace: platform-gateway-firmware-repository-dev
  labels:
    <redacted>

spec:
  replicas: 1
  selector:
    matchLabels:
      app: keda-operator
  template:
    metadata:
      labels:
        app: keda-operator
    spec:
      serviceAccountName: keda-operator
      securityContext:
        {}
      containers:
        - name: keda-operator
          securityContext:
            {}
          image: "docker.io/kedacore/keda:1.2.3"
    <redacted>
---
# Source: keda/templates/22-metrics-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: keda-operator-metrics-apiserver
  namespace: platform-gateway-firmware-repository-dev
  labels:
    <redacted>
spec:
  replicas: 1
  selector:
    matchLabels:
      app: keda-operator-metrics-apiserver
  template:
    metadata:
      labels:
        app: keda-operator-metrics-apiserver
      annotations:
    spec:
      serviceAccountName: keda-operator
      securityContext:
        {}
      containers:
        - name: keda-operator-metrics-apiserver
          securityContext:
            {}
          image: "docker.io/kedacore/keda-metrics-apiserver:5.6.7"
          imagePullPolicy: Always
    <redacted>
```