### PR TITLE
Change Helm Chart API version to v2

### DIFF
--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: keda
 description: Event-based autoscaler for workloads on Kubernetes
 


### PR DESCRIPTION
Fixes issue with argocd unable to install KEDA as argocd by default uses helm2 when `apiVersion` is set to `v1` in the `Chart.yaml`

Changes
Changed `apiVersion` to `v2` in `Chart.yaml` to automatically default argocd to use helm3 when installing the chart

References
https://argoproj.github.io/argo-cd/user-guide/helm/#helm-version