### PR TITLE
Adding the ability to add annotations to service

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -85,6 +85,7 @@ their default values.
 | `affinity`                             | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) | `{}` |
 | `priorityClassName`                    | Pod priority for KEDA Operator and Metrics Adapter ([docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)) | `` |
 | `env`                                  | Additional environment variables that will be passed onto KEDA operator and metrics api service | `` |
+| `service.annotations`                  | Annotations to add the KEDA Metric Server service | `{}`                                        |
 | `service.portHttp`                     | Service HTTP port for KEDA Metric Server service | `80`                                        |
 | `service.portHttpTarget`               | Service HTTP port for KEDA Metric Server container | `8080`                                        |
 | `service.portHttps`                    | HTTPS port for KEDA Metric Server service | `443`                                        |

--- a/keda/templates/23-metrics-service.yaml
+++ b/keda/templates/23-metrics-service.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ .Values.operator.name }}-metrics-apiserver
   namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   ports:
   - name: https

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -88,6 +88,8 @@ service:
   portHttps: 443
   portHttpsTarget: 6443
 
+  annotations: {}
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Adding the ability to add annotations to the service. This can be used for things like ArgoCD to guarantee order of installation to ensure the service exists before the APIService