### PR TITLE
Provide better documentation on watching namespaces

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -60,7 +60,7 @@ their default values.
 | `image.keda.tag`                       | Image tag of KEDA operator. Optional, given app version of Helm chart is used by default | ``                 |
 | `image.metricsApiServer.repository`    | Image name of KEDA Metrics API Server        | `docker.io/kedacore/keda-metrics-apiserver` |
 | `image.metricsApiServer.tag`           | Image tag of KEDA Metrics API Server. Optional, given app version of Helm chart is used by default | ``                 |
-| `watchNamespace`                       | Policy to use to pull Docker images       | `` |
+| `watchNamespace`                       | Defines Kubernetes namespaces to watch to scale their workloads. Default watches all namespaces | `` |
 | `operator.name`                        | Name of the KEDA operator | `keda-operator` |
 | `imagePullSecrets`                     | Name of secret to use to pull images to use to pull Docker images | `[]` |
 | `additionalLabels`                     | Additional labels to apply to KEDA workloads | `` |

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -64,7 +64,7 @@ spec:
             initialDelaySeconds: 20
           env:
             - name: WATCH_NAMESPACE
-              value: {{ .Values.watchNamespace }}
+              value: {{ .Values.watchNamespace | quote }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -62,7 +62,7 @@ spec:
             initialDelaySeconds: 5
           env:
             - name: WATCH_NAMESPACE
-              value: ""
+              value: {{ .Values.watchNamespace | quote }}
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 -}}
             {{- end }}


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Improvement for https://github.com/kedacore/keda/issues/1377

**Without:**
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: keda-operator
  namespace: platform-gateway-g3-dev
  labels:
    app: keda-operator
    name: keda-operator
    <redacted>
spec:
  replicas: 1
  selector:
    matchLabels:
      app: keda-operator
  template:
    metadata:
      labels:
        app: keda-operator
    spec:
      serviceAccountName: keda-operator
      securityContext:
        {}
      containers:
        - name: keda-operator
          securityContext:
            {}
          image: "docker.io/kedacore/keda:2.0.0"
          <redacted>
          env:
            - name: WATCH_NAMESPACE
              value: ""
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: OPERATOR_NAME
              value: keda-operator
          volumeMounts:
          resources:
            {}
      volumes:
---
# Source: keda/templates/22-metrics-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: keda-operator-metrics-apiserver
  namespace: platform-gateway-g3-dev
  labels:    
    <redacted>
spec:
  replicas: 1
  selector:
    matchLabels:
      app: keda-operator-metrics-apiserver
  template:
    metadata:
      labels:
        app: keda-operator-metrics-apiserver
      annotations:
    spec:
      serviceAccountName: keda-operator
      securityContext:
        {}
      containers:
        - name: keda-operator-metrics-apiserver
          securityContext:
            {}
          image: "docker.io/kedacore/keda-metrics-apiserver:2.0.0"
          <redacted>
          env:
            - name: WATCH_NAMESPACE
              value: ""
```

**With:**
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: keda-operator
  namespace: platform-gateway-g3-dev
  labels:
    app: keda-operator
    name: keda-operator
    <redacted>
spec:
  replicas: 1
  selector:
    matchLabels:
      app: keda-operator
  template:
    metadata:
      labels:
        app: keda-operator
    spec:
      serviceAccountName: keda-operator
      securityContext:
        {}
      containers:
        - name: keda-operator
          securityContext:
            {}
          image: "docker.io/kedacore/keda:2.0.0"
          <redacted>
          env:
            - name: WATCH_NAMESPACE
              value: "foo"
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: OPERATOR_NAME
              value: keda-operator
          volumeMounts:
          resources:
            {}
      volumes:
---
# Source: keda/templates/22-metrics-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: keda-operator-metrics-apiserver
  namespace: platform-gateway-g3-dev
  labels:    
    <redacted>
spec:
  replicas: 1
  selector:
    matchLabels:
      app: keda-operator-metrics-apiserver
  template:
    metadata:
      labels:
        app: keda-operator-metrics-apiserver
      annotations:
    spec:
      serviceAccountName: keda-operator
      securityContext:
        {}
      containers:
        - name: keda-operator-metrics-apiserver
          securityContext:
            {}
          image: "docker.io/kedacore/keda-metrics-apiserver:2.0.0"
          <redacted>
          env:
            - name: WATCH_NAMESPACE
              value: "foo"
```