### PR TITLE
Enabled extravolumes for both Keda and Metrics server deployment

### DIFF
--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -4,7 +4,7 @@ description: Event-based autoscaler for workloads on Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.2
+version: 2.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -4,7 +4,7 @@ description: Event-based autoscaler for workloads on Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.1
+version: 2.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -83,6 +83,9 @@ spec:
           - name: hashicorp-vault-certs
             mountPath: /hashicorp-vaultcerts
           {{- end }}
+          {{- if .Values.volumes.keda.extraVolumeMounts }}
+          {{- toYaml .Values.volumes.keda.extraVolumeMounts | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -95,6 +98,9 @@ spec:
       - name: hashicorp-vault-certs
         secret:
           secretName: {{ .Values.hashiCorpVaultTLS }}
+      {{- end }}
+      {{- if .Values.volumes.keda.extraVolumes }}
+      {{- toYaml .Values.volumes.keda.extraVolumes | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -96,6 +96,9 @@ spec:
           - name: hashicorp-vault-certs
             mountPath: /hashicorp-vaultcerts
           {{- end }}
+          {{- if .Values.volumes.metricsApiServer.extraVolumeMounts }}
+          {{- toYaml .Values.volumes.metricsApiServer.extraVolumeMounts | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -108,6 +111,9 @@ spec:
       - name: hashicorp-vault-certs
         secret:
           secretName: {{ .Values.hashiCorpVaultTLS }}
+      {{- end }}
+      {{- if .Values.volumes.metricsApiServer.extraVolumes }}
+      {{- toYaml .Values.volumes.metricsApiServer.extraVolumes | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -126,6 +126,16 @@ env:
 # - name: ENV_NAME
 #   value: 'ENV-VALUE'
 
+# Extra volumes and volume mounts for the deployment. Optional.
+volumes:
+  keda:
+    extraVolumes: []
+    extraVolumeMounts: []
+
+  metricsApiServer:
+    extraVolumes: []
+    extraVolumeMounts: []
+
 prometheus:
   enabled: false
   port: 9022


### PR DESCRIPTION
Enabled addition of extra volume mounts for both the Keda and the Metrics server deployment. This is needed if there is a need to run Metrics server with a read only root file system, hopefully there are other use cases where this can be useful too.

Ref #113 