### PR TITLE
Allow read/list/get of serviceaccounts

### DIFF
--- a/keda/templates/10-keda-clusterrole.yaml
+++ b/keda/templates/10-keda-clusterrole.yaml
@@ -26,6 +26,7 @@ rules:
   - pods
   - secrets
   - services
+  - serviceaccounts
   verbs:
   - get
   - list


### PR DESCRIPTION
Allow the operator to read serviceaccounts.

This is required for the [aws-eks pod identity provider](https://keda.sh/docs/2.0/concepts/authentication/#eks-pod-identity-webhook-for-aws) to work. IAM roles are bound to serviceAccounts (using an annotation), and so the operator needs to be able to read the relevant serviceAccount in order to discover which role it should assume.

