### PR TITLE
Allow list/watch of deployments and statefullset

### DIFF
--- a/keda/templates/10-keda-clusterrole.yaml
+++ b/keda/templates/10-keda-clusterrole.yaml
@@ -43,6 +43,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers


### PR DESCRIPTION
I am getting error after helm upgrade

```
E0128 02:33:19.968637       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1.Deployment: failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:keda:keda-operator" cannot list resource "deployments" in API group "apps" at the cluster scope
```

https://github.com/kedacore/keda/blob/f11984582ca412d0de526b0e4022b1d268e02d56/config/rbac/role.yaml#L40-L47

https://github.com/kedacore/keda/commit/f3b34d902a6ec62f1563bed5d86a134d8260a0c9