### PR TITLE
Allow define number of replicas of keda

### DIFF
--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -4,7 +4,7 @@ description: Event-based autoscaler for workloads on Kubernetes
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.0
+version: 2.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/keda/README.md
+++ b/keda/README.md
@@ -72,6 +72,7 @@ their default values.
 | `podLabels.keda`                                           | Pod labels for KEDA operator | `{}` |
 | `podLabels.metricsAdapter`                                 | Pod labels for KEDA Metrics Adapter | `{}` |
 | `podDisruptionBudget`                                      | Capability to configure [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)       | `{}` |
+| `keda.replicaCount`                                      | Capability to configure number of replicas for Keda   | `1` |
 | `rbac.create`                                              | Specifies whether RBAC should be used | `true`                                        |
 | `serviceAccount.create`                                    | Specifies whether a service account should be created       | `true`                                        |
 | `serviceAccount.name`                                      | The name of the service account to use. If not set and create is true, a name is generated.      | `keda-operator` |

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.keda.replicaCount}}
   selector:
     matchLabels:
       app: {{ .Values.operator.name }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -44,6 +44,9 @@ podDisruptionBudget: {}
 #  minAvailable: 1
 #  maxUnavailable: 1
 
+keda:
+  replicaCount: 1
+
 rbac:
   create: true
 


### PR DESCRIPTION
Allow to define number of replicas for Keda for HA.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*
