### PR TITLE
feat: added ability to enable host network for keda metrics server

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -63,6 +63,7 @@ their default values.
 | `crds.install`                               | Defines whether the KEDA CRDs have to be installed or not. | `true`                 |
 | `watchNamespace`                                           | Defines Kubernetes namespaces to watch to scale their workloads. Default watches all namespaces | `` |
 | `operator.name`                                            | Name of the KEDA operator | `keda-operator` |
+| `metricsServer.useHostNetwork`                             | Enable metric server to use host network  | `false`
 | `imagePullSecrets`                                         | Name of secret to use to pull images to use to pull Docker images | `[]` |
 | `additionalLabels`                                         | Additional labels to apply to KEDA workloads | `` |
 | `podAnnotations.keda`                                      | Pod annotations for KEDA operator | `{}` |

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -112,6 +112,7 @@ spec:
         secret:
           secretName: {{ .Values.hashiCorpVaultTLS }}
       {{- end }}
+      hostNetwork: {{ .Values.metricsServer.useHostNetwork }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -22,6 +22,9 @@ imagePullSecrets: []
 operator:
   name: keda-operator
 
+metricsServer:  
+  useHostNetwork: false
+
 additionalLabels: ""
 podAnnotations:
   keda: {}


### PR DESCRIPTION
Signed-off-by: Matthew Ingle <mringle94@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md
-->

This pull request adds a configuration option for the keda metrics server to use host network. In environments such as EKS this is important as the masters are unable to communicate with the pods directly in the CNI. (Similar to this issue with the ELK operator https://github.com/elastic/cloud-on-k8s/issues/1369)

By default hostnetwork is disable this simply enables operators to flip it on if needed.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*