### PR TITLE
Corrected HTTP timeout env var

### DIFF
--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - name: OPERATOR_NAME
               value: {{ .Values.operator.name }}
             {{- if .Values.http.timeout }}
-            - name: KEDA_DEFAULT_HTTP_TIMEOUT
+            - name: KEDA_HTTP_DEFAULT_TIMEOUT
               value: {{ .Values.http.timeout | quote }}
             {{- end }}
             {{- if .Values.env }}


### PR DESCRIPTION
Signed-off-by: Jens De Temmerman <jens.dt@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md
-->

As per https://keda.sh/docs/2.2/operate/cluster/#http-timeouts, the correct env var should be KEDA_HTTP_DEFAULT_TIMEOUT

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*
