### PR TITLE
Improve CI for KEDA & KEDA HTTP

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -6,11 +6,13 @@ on:
     branches:
       - master
     paths:
+      - '.github/workflows/ci-core.yml'
       - 'keda/**'
   pull_request:
     branches:
       - master
     paths:
+      - '.github/workflows/ci-core.yml'
       - 'keda/**'
 
 jobs:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -1,5 +1,17 @@
-name: Helm Chart CI
-on: [pull_request]
+name: Helm Chart CI (Core)
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+    paths:
+      - 'keda/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'keda/**'
 
 jobs:
   lint-helm-3-x:

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -6,11 +6,13 @@ on:
     branches:
       - master
     paths:
+      - '.github/workflows/ci-http-add-on.yml'
       - 'http-add-on/**'
   pull_request:
     branches:
       - master
     paths:
+      - '.github/workflows/ci-http-add-on.yml'
       - 'http-add-on/**'
 
 jobs:

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -1,5 +1,17 @@
-name: HTTP add-on Helm Chart CI
-on: [pull_request]
+name: Helm Chart CI (HTTP add-on)
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+    paths:
+      - 'http-add-on/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'http-add-on/**'
 
 jobs:
   lint-helm-3-x:
@@ -38,7 +50,7 @@ jobs:
       run: kubectl create ns keda
 
     - name: Install Keda chart
-      run: helm install keda kedacore/keda --namespace keda
+      run: helm install keda ./keda/ --namespace keda
 
     - name: Template Helm chart
       run: helm template http-add-on ./http-add-on/ --namespace keda

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -64,4 +64,10 @@ jobs:
       run: kubectl get httpscaledobjects
 
     - name: Get all CRDs
-      run: kubectl get crds/httpscaledobjects
+      run: kubectl get crds
+
+    - name: Get HTTPScaledObject CRD
+      run: kubectl get crds/httpscaledobjects.http.keda.sh
+
+    - name: Describe HTTPScaledObject CRD
+      run: kubectl describe crds/httpscaledobjects.http.keda.sh


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md
-->

Improve CI for KEDA & KEDA HTTP so that:
- Workflow names & file names are aligned
- Only trigger for master pushes/PRs matching folder path
- Fix CI for KEDA HTTP

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] README is updated with new configuration values *(if applicable)*

Relates to #137
Relates to https://github.com/kedacore/http-add-on/issues/104