### PR TITLE
Default image tag and remove 'v' prefix

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -82,7 +82,7 @@ their default values.
 
 | Parameter                                                  | Description                               | Default                                         |
 |:-----------------------------------------------------------|:------------------------------------------|:------------------------------------------------|
-| `images.tag`                                               | Image tag for the http add on             | `latest`                              |
+| `images.tag`                                               | Image tag for the http add on             | None, it uses Helm chart's app version as a default                              |
 | `images.operator`                                          | Image name for the operator image component | `ghcr.io/kedacore/http-add-on-operator:latest` |
 | `images.interceptor`                                       | Image name for the interceptor image component | `ghcr.io/kedacore/http-add-on-interceptor:latest` |
 | `images.scaler`                                            | Image name for the scaler image component | `ghcr.io/kedacore/http-add-on-scaler:latest` |

--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -82,11 +82,10 @@ their default values.
 
 | Parameter                                                  | Description                               | Default                                         |
 |:-----------------------------------------------------------|:------------------------------------------|:------------------------------------------------|
-| `version`                                                  | Image tag for the http add on             | The latest release                              |
+| `images.tag`                                               | Image tag for the http add on             | `latest`                              |
 | `images.operator`                                          | Image name for the operator image component | `ghcr.io/kedacore/http-add-on-operator:latest` |
 | `images.interceptor`                                       | Image name for the interceptor image component | `ghcr.io/kedacore/http-add-on-interceptor:latest` |
 | `images.scaler`                                            | Image name for the scaler image component | `ghcr.io/kedacore/http-add-on-scaler:latest` |
-
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`. For example:

--- a/http-add-on/templates/deployment.yaml
+++ b/http-add-on/templates/deployment.yaml
@@ -3,12 +3,12 @@ kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-controller-manager
     app.kubernetes.io/name: {{ .Chart.Name }}-controller-manager
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -21,18 +21,18 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-      httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+      httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
       keda.sh/addon: {{ .Chart.Name }}
   template:
     metadata:
       labels:
         control-plane: controller-manager
-        httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+        httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
         keda.sh/addon: {{ .Chart.Name }}
         app: {{ .Chart.Name }}
         name: {{ .Chart.Name }}-operator
         app.kubernetes.io/name: {{ .Chart.Name }}-operator
-        app.kubernetes.io/version: {{ .Chart.AppVersion }}
+        app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
         app.kubernetes.io/component: operator
         app.kubernetes.io/part-of: {{ .Chart.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/http-add-on/templates/deployment.yaml
+++ b/http-add-on/templates/deployment.yaml
@@ -3,12 +3,12 @@ kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-    httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-controller-manager
     app.kubernetes.io/name: {{ .Chart.Name }}-controller-manager
-    app.kubernetes.io/version: {{ .Values.version }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -21,18 +21,18 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-      httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+      httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
       keda.sh/addon: {{ .Chart.Name }}
   template:
     metadata:
       labels:
         control-plane: controller-manager
-        httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+        httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
         keda.sh/addon: {{ .Chart.Name }}
         app: {{ .Chart.Name }}
         name: {{ .Chart.Name }}-operator
         app.kubernetes.io/name: {{ .Chart.Name }}-operator
-        app.kubernetes.io/version: {{ .Values.version }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         app.kubernetes.io/component: operator
         app.kubernetes.io/part-of: {{ .Chart.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -50,14 +50,14 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        image: "{{ .Values.images.operator }}:v{{ .Values.version | default .Chart.AppVersion }}"
+        image: "{{ .Values.images.operator }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.operator.pullPolicy | default "Always" }}
         name: {{ .Chart.Name }}-operator
         env:
         - name: KEDAHTTP_OPERATOR_EXTERNAL_SCALER_IMAGE
-          value: "{{ .Values.images.scaler }}:v{{ .Values.version | default .Chart.AppVersion }}"
+          value: "{{ .Values.images.scaler }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         - name: KEDAHTTP_OPERATOR_INTERCEPTOR_IMAGE
-          value: "{{ .Values.images.interceptor }}:v{{ .Values.version | default .Chart.AppVersion }}"
+          value: "{{ .Values.images.interceptor }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         - name: INTERCEPTOR_PULL_POLICY
           value: {{ .Values.operator.pullPolicy | default "Always" }}
         - name: SCALER_PULL_POLICY

--- a/http-add-on/templates/rbac.yml
+++ b/http-add-on/templates/rbac.yml
@@ -2,12 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-leader-election-role
     app.kubernetes.io/name: {{ .Chart.Name }}-leader-election-role
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -48,12 +48,12 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-manager-role
     app.kubernetes.io/name: {{ .Chart.Name }}-manager-role
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -142,12 +142,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-proxy-role
     app.kubernetes.io/name: {{ .Chart.Name }}-proxy-role
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -172,12 +172,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-metrics-reader
     app.kubernetes.io/name: {{ .Chart.Name }}-metrics-reader
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -194,12 +194,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-leader-election-binding
     app.kubernetes.io/name: {{ .Chart.Name }}-leader-election-rolebinding
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -220,12 +220,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-manager-rolebinding
     app.kubernetes.io/name: {{ .Chart.Name }}-manager-rolebinding
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -245,12 +245,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-proxy-rolebinding
     app.kubernetes.io/name: {{ .Chart.Name }}-proxy-rolebinding
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/http-add-on/templates/rbac.yml
+++ b/http-add-on/templates/rbac.yml
@@ -2,12 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-leader-election-role
     app.kubernetes.io/name: {{ .Chart.Name }}-leader-election-role
-    app.kubernetes.io/version: {{ .Values.version }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -48,12 +48,12 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-manager-role
     app.kubernetes.io/name: {{ .Chart.Name }}-manager-role
-    app.kubernetes.io/version: {{ .Values.version }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -142,12 +142,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-proxy-role
     app.kubernetes.io/name: {{ .Chart.Name }}-proxy-role
-    app.kubernetes.io/version: {{ .Values.version }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -172,12 +172,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-metrics-reader
     app.kubernetes.io/name: {{ .Chart.Name }}-metrics-reader
-    app.kubernetes.io/version: {{ .Values.version }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -194,12 +194,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-leader-election-binding
     app.kubernetes.io/name: {{ .Chart.Name }}-leader-election-rolebinding
-    app.kubernetes.io/version: {{ .Values.version }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -220,12 +220,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-manager-rolebinding
     app.kubernetes.io/name: {{ .Chart.Name }}-manager-rolebinding
-    app.kubernetes.io/version: {{ .Values.version }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -245,12 +245,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-proxy-rolebinding
     app.kubernetes.io/name: {{ .Chart.Name }}-proxy-rolebinding
-    app.kubernetes.io/version: {{ .Values.version }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/http-add-on/templates/svc.yaml
+++ b/http-add-on/templates/svc.yaml
@@ -3,12 +3,12 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-controller-manager-metrics-service
     app.kubernetes.io/name: {{ .Chart.Name }}-controller-manager-metrics-service
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -23,5 +23,5 @@ spec:
     targetPort: https
   selector:
     control-plane: controller-manager
-    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}

--- a/http-add-on/templates/svc.yaml
+++ b/http-add-on/templates/svc.yaml
@@ -3,12 +3,12 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-    httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
     name: {{ .Chart.Name }}-controller-manager-metrics-service
     app.kubernetes.io/name: {{ .Chart.Name }}-controller-manager-metrics-service
-    app.kubernetes.io/version: {{ .Values.version }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: controller-manager
     app.kubernetes.io/part-of: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -23,5 +23,5 @@ spec:
     targetPort: https
   selector:
     control-plane: controller-manager
-    httpscaledobjects.http.keda.sh/version: {{ .Values.version }}
+    httpscaledobjects.http.keda.sh/version: {{ .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -15,7 +15,7 @@ operator:
   port: 8443
 
 images:
-  tag: latest
+  tag:
   operator: ghcr.io/kedacore/http-add-on-operator
   interceptor: ghcr.io/kedacore/http-add-on-interceptor
   scaler: ghcr.io/kedacore/http-add-on-scaler

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -1,5 +1,3 @@
-version: v0.1.0-v1alpha1
-
 additionalLabels: ""
 
 crds:
@@ -17,6 +15,7 @@ operator:
   port: 8443
 
 images:
+  tag: latest
   operator: ghcr.io/kedacore/http-add-on-operator
   interceptor: ghcr.io/kedacore/http-add-on-interceptor
   scaler: ghcr.io/kedacore/http-add-on-scaler


### PR DESCRIPTION
Removes the 'v' prefix from images and defaults the image tag to latest or the chart version

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #150
Related to https://github.com/kedacore/http-add-on/pull/167 and https://github.com/kedacore/http-add-on/pull/125
