### PR TITLE
HTTP Addon: Adding CRD fields for target metric configuration

### DIFF
--- a/http-add-on/templates/crd.yaml
+++ b/http-add-on/templates/crd.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.crds.install }}
+
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -44,10 +45,14 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -58,19 +63,23 @@ spec:
                 description: (optional) Replica information
                 properties:
                   max:
-                    description: Maximum amount of replicas to have in the deployment (Default 100)
+                    description: Maximum amount of replicas to have in the deployment
+                      (Default 100)
                     format: int32
                     type: integer
                   min:
-                    description: Minimum amount of replicas to have in the deployment (Default 0)
+                    description: Minimum amount of replicas to have in the deployment
+                      (Default 0)
                     format: int32
                     type: integer
                 type: object
               scaleTargetRef:
-                description: The name of the deployment to route HTTP requests to (and to autoscale). Either this or Image must be set
+                description: The name of the deployment to route HTTP requests to
+                  (and to autoscale). Either this or Image must be set
                 properties:
                   deployment:
-                    description: The name of the deployment to scale according to HTTP traffic
+                    description: The name of the deployment to scale according to
+                      HTTP traffic
                     type: string
                   port:
                     description: The port to route to
@@ -84,6 +93,10 @@ spec:
                 - port
                 - service
                 type: object
+              targetMetric:
+                description: (optional) Target metric value
+                format: int32
+                type: integer
             required:
             - scaleTargetRef
             type: object
@@ -96,7 +109,8 @@ spec:
                   description: Condition to store the condition state
                   properties:
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.
@@ -164,4 +178,5 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 {{- end -}}


### PR DESCRIPTION
In https://github.com/kedacore/http-add-on/pull/168, we've added fields in the CRD for `HTTPScaledObject`s to allow users to specify the target metric. This PR updates the CRD in the helm chart to add those fields.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- ~[ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*~
- [x] README is updated with new configuration values *(if applicable)*

Fixes #
