### PR TITLE
chore: Get all cluster trigger authentication resources in CI

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -81,6 +81,9 @@ jobs:
     - name: Get all TriggerAuthentication
       run: kubectl get triggerauth -o wide
 
+    - name: Get all ClusterTriggerAuthentication
+      run: kubectl get clustertriggerauth -o wide
+
     - name: Deploy Nginx with autoscaling
       run: kubectl apply -f ./samples/nginx-scaledobject.yml
 


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md
-->

Get all cluster trigger authentication resources in CI.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] README is updated with new configuration values *(if applicable)*

Fixes #
