### PR TITLE
feat: expose operator metrics via a service

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -92,11 +92,14 @@ their default values.
 | `priorityClassName`                                        | Pod priority for KEDA Operator and Metrics Adapter ([docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)) | `` |
 | `env`                                                      | Additional environment variables that will be passed onto KEDA operator and metrics api service | `` |
 | `http.timeout` | The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them) | `` |
-| `service.annotations`                                      | Annotations to add the KEDA Metric Server service | `{}`                                        |
-| `service.portHttp`                                         | Service HTTP port for KEDA Metric Server service | `80`                                        |
-| `service.portHttpTarget`                                   | Service HTTP port for KEDA Metric Server container | `8080`                                        |
-| `service.portHttps`                                        | HTTPS port for KEDA Metric Server service | `443`                                        |
-| `service.portHttpsTarget`                                  | HTTPS port for KEDA Metric Server container | `6443`                                        |
+| `service.operator.annotations`                             | Annotations to add the KEDA Operator service | `{}`                                        |
+| `service.operator.portHttp`                                | Service HTTP port for KEDA Operator service | `80`                                        |
+| `service.operator.portHttpTarget`                          | Service HTTP port for KEDA Operator container | `8080`                                        |
+| `service.metricServer.annotations`                         | Annotations to add the KEDA Metric Server service | `{}`                                        |
+| `service.metricServer.portHttp`                            | Service HTTP port for KEDA Metric Server service | `80`                                        |
+| `service.metricServer.portHttpTarget`                      | Service HTTP port for KEDA Metric Server container | `8080`                                        |
+| `service.metricServer.portHttps`                           | HTTPS port for KEDA Metric Server service | `443`                                        |
+| `service.metricServer.portHttpsTarget`                     | HTTPS port for KEDA Metric Server container | `6443`             –                           |
 | `prometheus.metricServer.enabled`                          | Enable metric server prometheus metrics expose | `false`
 | `prometheus.metricServer.port`                             | HTTP port used for exposing metrics server prometheus metrics | `9022`
 | `prometheus.metricServer.portName`                         | HTTP port name for exposing metrics server prometheus metrics | `metrics`
@@ -107,7 +110,6 @@ their default values.
 | `prometheus.metricServer.podMonitor.namespace`             | Scraping namespace for metric server using podMonitor crd (prometheus operator) | ``
 | `prometheus.metricServer.podMonitor.additionalLabels`      | Additional labels to add for metric server using podMonitor crd (prometheus operator) | `{}`
 | `prometheus.operator.enabled`                              | Enable keda operator prometheus metrics expose | `false`
-| `prometheus.operator.port`                                 | HTTP port used for exposing keda operator prometheus metrics | `9022`
 | `prometheus.operator.path`                                 | Path used for exposing keda operator prometheus metrics | `/metrics`
 | `prometheus.operator.podMonitor.enabled`                   | Enable monitoring for keda operator using podMonitor crd (prometheus operator) | `false`
 | `prometheus.operator.podMonitor.interval`                  | Scraping interval for keda operator using podMonitor crd (prometheus operator) | ``

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -54,6 +54,7 @@ spec:
           - --enable-leader-election
           - "--zap-log-level={{ .Values.logging.operator.level }}"
           - "--zap-encoder={{ .Values.logging.operator.format }}"
+          - "--metrics-addr=:{{ .Values.service.operator.portHttpTarget }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             httpGet:
@@ -66,7 +67,7 @@ spec:
               port: 8081
             initialDelaySeconds: 20
           ports:
-          - containerPort: 8080
+          - containerPort: {{ .Values.service.operator.portHttpTarget }}
             name: http
             protocol: TCP
           env:

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -54,13 +54,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: {{ .Values.service.portHttpsTarget }}
+              port: {{ .Values.service.metricServer.portHttpsTarget }}
               scheme: HTTPS
             initialDelaySeconds: 5
           readinessProbe:
             httpGet:
               path: /readyz
-              port: {{ .Values.service.portHttpsTarget }}
+              port: {{ .Values.service.metricServer.portHttpsTarget }}
               scheme: HTTPS
             initialDelaySeconds: 5
           env:
@@ -71,7 +71,7 @@ spec:
             {{- end }}
           args:
           - /usr/local/bin/keda-adapter
-          - --secure-port={{ .Values.service.portHttpsTarget }}
+          - --secure-port={{ .Values.service.metricServer.portHttpsTarget }}
           - --logtostderr=true
           {{- if .Values.prometheus.metricServer.enabled }}
           - --metrics-port={{ .Values.prometheus.metricServer.port }}
@@ -79,10 +79,10 @@ spec:
           {{- end }}
           - --v={{ .Values.logging.metricServer.level }}
           ports:
-            - containerPort: {{ .Values.service.portHttpsTarget }}
+            - containerPort: {{ .Values.service.metricServer.portHttpsTarget }}
               name: https
               protocol: TCP
-            - containerPort: {{ .Values.service.portHttpTarget }}
+            - containerPort: {{ .Values.service.metricServer.portHttpTarget }}
               name: http
               protocol: TCP
             {{- if .Values.prometheus.metricServer.enabled }}

--- a/keda/templates/23-metrics-service.yaml
+++ b/keda/templates/23-metrics-service.yaml
@@ -16,12 +16,12 @@ metadata:
 spec:
   ports:
   - name: https
-    port: {{ .Values.service.portHttps }}
-    targetPort: {{ .Values.service.portHttpsTarget }}
+    port: {{ .Values.service.metricServer.portHttps }}
+    targetPort: {{ .Values.service.metricServer.portHttpsTarget }}
     protocol: TCP
   - name: http
-    port: {{ .Values.service.portHttp }}
-    targetPort: {{ .Values.service.portHttpTarget }}
+    port: {{ .Values.service.metricServer.portHttp }}
+    targetPort: {{ .Values.service.metricServer.portHttpTarget }}
     protocol: TCP
   {{- if .Values.prometheus.metricServer.enabled }}
   - name: {{ .Values.prometheus.metricServer.portName }}

--- a/keda/templates/27-keda-service.yaml
+++ b/keda/templates/27-keda-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Values.operator.name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: {{ .Values.operator.name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  name: {{ .Values.operator.name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  ports:
+  - name: http
+    port: {{ .Values.service.operator.portHttp }}
+    targetPort: {{ .Values.service.operator.portHttpTarget }}
+    protocol: TCP
+  selector:
+    app: {{ .Values.operator.name }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -96,13 +96,18 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
-  type: ClusterIP
-  portHttp: 80
-  portHttpTarget: 8080
-  portHttps: 443
-  portHttpsTarget: 6443
-
-  annotations: {}
+  operator:
+    type: ClusterIP
+    portHttp: 80
+    portHttpTarget: 8080
+    annotations: {}
+  metricServer:
+    type: ClusterIP
+    portHttp: 80
+    portHttpTarget: 8080
+    portHttps: 443
+    portHttpsTarget: 6443
+    annotations: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -171,7 +176,6 @@ prometheus:
       additionalLabels: {}
   operator:
     enabled: false
-    port: 8080
     path: /metrics
     podMonitor:
       # Enables PodMonitor creation for the Prometheus Operator


### PR DESCRIPTION
Signed-off-by: Sandes de Silva <sandes.de.silva@roadmunk.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_
- add a service for operator that forwards the target port to `metrics-addr` arg
- expose operator metrics at `http://keda-operator.<namespace>.svc.cluster.local/metrics`

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Fixes #
