### PR TITLE
chore: KEDA was accepted as CNCF Incubation project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ KEDA allows for fine grained autoscaling (including to/from zero) for event driv
 
 KEDA can run on both the cloud and the edge, integrates natively with Kubernetes components such as the Horizontal Pod Autoscaler, and has no external dependencies.
 
-We are a Cloud Native Computing Foundation (CNCF) sandbox project.
+We are a Cloud Native Computing Foundation (CNCF) incubation project.
 ![CNCF Logo](https://raw.githubusercontent.com/kedacore/keda/main/images/logo-cncf.svg)
 
 ## Getting Started

--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -35,7 +35,7 @@ Please see the [complete installation instructions](https://github.com/kedacore/
 Please see the [contributing documentation for all instructions](https://github.com/kedacore/http-add-on/tree/main/docs/contributing.md).
 
 ---
-We are a Cloud Native Computing Foundation (CNCF) sandbox project.
+We are a Cloud Native Computing Foundation (CNCF) incubation project.
 <p align="center"><img src="https://raw.githubusercontent.com/kedacore/keda/main/images/logo-cncf.svg" height="75px"></p>
 
 ---

--- a/keda/README.md
+++ b/keda/README.md
@@ -7,7 +7,7 @@ KEDA can run on both the cloud and the edge, integrates natively with Kubernetes
 
 ---
 <p align="center">
-We are a Cloud Native Computing Foundation (CNCF) sandbox project.
+We are a Cloud Native Computing Foundation (CNCF) incubation project.
 
 <img src="https://raw.githubusercontent.com/kedacore/keda/master/images/logo-cncf.svg" height="75px">
 </p>


### PR DESCRIPTION
KEDA was accepted as CNCF Incubation project as per https://github.com/cncf/toc/pull/622

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] README is updated with new configuration values *(if applicable)*

Relates to https://github.com/kedacore/governance/issues/2