### PR TITLE
Add support to set `KEDA_HTTP_DEFAULT_TIMEOUT` in metrics server

### DIFF
--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -66,6 +66,10 @@ spec:
           env:
             - name: WATCH_NAMESPACE
               value: {{ .Values.watchNamespace | quote }}
+            {{- if .Values.http.timeout }}
+            - name: KEDA_HTTP_DEFAULT_TIMEOUT
+              value: {{ .Values.http.timeout | quote }}
+            {{- end }}
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 -}}
             {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md
-->

This PR adds support to set `KEDA_HTTP_DEFAULT_TIMEOUT` in metrics-server by the same way that we are using for the operator.
I have created the PR following these steps, https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md. Let me know if it's correct or I have to do/undo anything else :) 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)* https://github.com/kedacore/keda/pull/2062
- [x] README is updated with new configuration values *(if applicable)*

Fixes https://github.com/kedacore/charts/issues/180
