### PR TITLE
Add resource requests/limits for KEDA deployment

### DIFF
--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -104,17 +104,18 @@ service:
 
   annotations: {}
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# We provides the default values that we describe in our docs:
+# https://keda.sh/docs/latest/operate/cluster/
+# If you want to specify the resources (or totally remove the defaults), change or comment the following
+# lines, adjust them as necessary, or simply add the curly braces after 'operator' and/or 'metricServer'
+# and remove/comment the default values
+resources: 
+  limits:
+    cpu: 1
+    memory: 1000Mi
+  requests:
+    cpu: 100m
+    memory: 100Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
This PR adds default values in chart for resources. This default values are the [values provided in the documentation](https://keda.sh/docs/2.4/operate/cluster/#cluster-capacity-requirements)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Fixes https://github.com/kedacore/charts/issues/112
