### PR TITLE
use .Values.serviceAccount.name for rolebinding

### DIFF
--- a/keda/templates/11-keda-clusterrolebinding.yaml
+++ b/keda/templates/11-keda-clusterrolebinding.yaml
@@ -12,6 +12,6 @@ roleRef:
   name: {{ .Values.operator.name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.operator.name }}
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/keda/templates/21-metrics-clusterrolebinding.yaml
+++ b/keda/templates/21-metrics-clusterrolebinding.yaml
@@ -12,7 +12,7 @@ roleRef:
   name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.operator.name }}
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -29,7 +29,7 @@ roleRef:
   name: extension-apiserver-authentication-reader
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.operator.name }}
+  name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Signed-off-by: Xiayang Wu <xwu@rippling.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

For https://github.com/kedacore/charts/issues/189
The rolebindings did not use the serviceAccount.name, and the helmchart will only work when setting `serviceAccount.name` same as `operator.name`, which is not always the case

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Fixes #
