### PR TITLE
Fix: container argument for keda-operator in 12-keda-deployment.yaml

### DIFF
--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           command:
           - "/keda"
           args:
-          - --leader-elect
+          - "-enable-leader-election"
           - "--zap-log-level={{ .Values.logging.operator.level }}"
           - "--zap-encoder={{ .Values.logging.operator.format }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md
-->

Fixed keda-operator container argument causing pod crashloop

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] README is updated with new configuration values *(if applicable)*

Fixes #191
