### PR TITLE
Adding release instructions for the HTTP Addon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,7 @@ Thanks for helping making KEDA better!
 You can easily release a new Helm chart version:
 
 1. Update the version of the Helm chart in `Chart.yaml`
-1. Package the Helm chart
-   
+2. Package the Helm chart 
    - For KEDA:
     ```shell
     $ helm package keda
@@ -20,29 +19,22 @@ You can easily release a new Helm chart version:
     $ helm package http-add-on
     Successfully packaged chart and saved it to: /home/ecomaz/src/keda/charts/keda-add-ons-http-0.2.0.tgz
     ```
-
-1. Move the new chart to the docs folder:
-
+3. Move the new chart to the docs folder:
 ```shell
 $ mv keda-*.tgz docs
 ```
-
-1. Re-index the Helm repo to add our new version:
-
+4. Re-index the Helm repo to add our new version:
 ```shell
 $ helm repo index docs --url https://kedacore.github.io/charts
 ```
-
-1. Commit changes:
-
+5. Commit changes:
 ```shell
 git add .
 git commit -sm "Packaged new Helm chart version"
 git push origin chart-release
 ```
-
-1. Create a pull request with our new Helm index
-1.  Create a GitHub release for your new Helm chart version by using the following template
+6. Create a pull request with our new Helm index
+7.  Create a GitHub release for your new Helm chart version by using the following template
 
 > *Chart: {{Chart Version}} | App: {{App Name}}*
 > {{Description about the Helm chart}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,31 +8,41 @@ Thanks for helping making KEDA better!
 You can easily release a new Helm chart version:
 
 1. Update the version of the Helm chart in `Chart.yaml`
-2. Package the Helm chart
+2. Package the Helm chart. For KEDA:
 ```shell
 $ helm package keda
 Successfully packaged chart and saved it to: C:\Code\GitHub\charts\keda-0.1.0.tgz
 ```
 
-3. Move the new chart to the docs folder
+For HTTP Addon:
+
+```shell
+$ helm package http-add-on
+Successfully packaged chart and saved it to: /home/ecomaz/src/keda/charts/keda-add-ons-http-0.2.0.tgz
+```
+
+1. Move the new chart to the docs folder. For both KEDA and the HTTP Addon, use the below command:
+
 ```shell
 $ mv keda-*.tgz docs
 ```
 
-4. Re-index the Helm repo to add our new version
+1. Re-index the Helm repo to add our new version. For both KEDA and the HTTP Addon, use the below command:
+
 ```shell
 $ helm repo index docs --url https://kedacore.github.io/charts
 ```
 
-5. Commit changes
+1. Commit changes. For both KEDA and the HTTP Addon, use the below command:
+
 ```shell
 git add .
 git commit -sm "Packaged new Helm chart version"
 git push origin chart-release
 ```
 
-6. Create a pull request with our new Helm index
-7. Create a GitHub release for your new Helm chart version by using the following template
+1. Create a pull request with our new Helm index
+2. Create a GitHub release for your new Helm chart version by using the following template
 
 > *Chart: {{Chart Version}} | App: {{App Name}}*
 > {{Description about the Helm chart}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,32 +8,32 @@ Thanks for helping making KEDA better!
 You can easily release a new Helm chart version:
 
 1. Update the version of the Helm chart in `Chart.yaml`
-2. Package the Helm chart. For KEDA:
-```shell
-$ helm package keda
-Successfully packaged chart and saved it to: C:\Code\GitHub\charts\keda-0.1.0.tgz
-```
+1. Package the Helm chart
+   
+   - For KEDA:
+    ```shell
+    $ helm package keda
+    Successfully packaged chart and saved it to: C:\Code\GitHub\charts\keda-0.1.0.tgz
+    ```
+   - For HTTP Addon:
+    ```shell
+    $ helm package http-add-on
+    Successfully packaged chart and saved it to: /home/ecomaz/src/keda/charts/keda-add-ons-http-0.2.0.tgz
+    ```
 
-For HTTP Addon:
-
-```shell
-$ helm package http-add-on
-Successfully packaged chart and saved it to: /home/ecomaz/src/keda/charts/keda-add-ons-http-0.2.0.tgz
-```
-
-1. Move the new chart to the docs folder. For both KEDA and the HTTP Addon, use the below command:
+1. Move the new chart to the docs folder:
 
 ```shell
 $ mv keda-*.tgz docs
 ```
 
-1. Re-index the Helm repo to add our new version. For both KEDA and the HTTP Addon, use the below command:
+1. Re-index the Helm repo to add our new version:
 
 ```shell
 $ helm repo index docs --url https://kedacore.github.io/charts
 ```
 
-1. Commit changes. For both KEDA and the HTTP Addon, use the below command:
+1. Commit changes:
 
 ```shell
 git add .
@@ -42,7 +42,7 @@ git push origin chart-release
 ```
 
 1. Create a pull request with our new Helm index
-2. Create a GitHub release for your new Helm chart version by using the following template
+1.  Create a GitHub release for your new Helm chart version by using the following template
 
 > *Chart: {{Chart Version}} | App: {{App Name}}*
 > {{Description about the Helm chart}}


### PR DESCRIPTION
This PR adds instructions to `CONTRIBUTING.md` for releasing the HTTP Addon

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- ~A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)* (N/A)~
- ~README is updated with new configuration values *(if applicable)* (N/A)~

Fixes #
