### PR TITLE
docs: Centralize maintainer overview

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,19 +1,3 @@
 # Kubernetes Event-driven Autoscaling (KEDA) Maintainers
 
-## Current
-
-| Maintainer           | GitHub ID                                     | Affiliation |
-| -------------------- | --------------------------------------------- | ----------- |
-| Jeff Hollan          | [jeffhollan](https://github.com/jeffhollan)   | Microsoft   |
-| Anirudh Garg         | [anirudhgarg](https://github.com/anirudhgarg) | Microsoft   |
-| Ahmed ElSayed        | [ahmelsayed](https://github.com/ahmelsayed)   | Microsoft   |
-| Zbynek Roubalik      | [zroubalik](https://github.com/zroubalik)     | Red Hat     |
-| Tom Kerkhove         | [tomkerkhove](https://github.com/tomkerkhove) | Codit       |
-
-## Alumni
-
-| Maintainer           | GitHub ID                                     | Affiliation |
-| -------------------- | --------------------------------------------- | ----------- |
-| Aarthi Saravanakumar | [Aarthisk](https://github.com/Aarthisk)       | Microsoft   |
-| Yaron Schneider      | [yaron2](https://github.com/yaron2)           | Microsoft   |
-| Ben Browning         | [bbrowning](https://github.com/bbrowning)     | Red Hat     |
+You can find an overview of our current and alumni maintainers [here](https://github.com/kedacore/governance/blob/main/MAINTAINERS.md).


### PR DESCRIPTION
Centralize maintainer overview and point to our keda/governance repo.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- ~A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*~
- ~README is updated with new configuration values *(if applicable)*~