### PR TITLE
feat: Add optional `namespace` value

### DIFF
--- a/http-add-on/templates/deployment-interceptor.yaml
+++ b/http-add-on/templates/deployment-interceptor.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{ tpl .Values.additionalLabels . | indent 4}}
   name: {{ .Chart.Name }}-interceptor
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 spec:
   replicas: 1
   selector:

--- a/http-add-on/templates/deployment-operator.yaml
+++ b/http-add-on/templates/deployment-operator.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}-controller-manager
     {{- include "keda-addons-http.labels" . | indent 4 }}
   name: {{ .Chart.Name }}-controller-manager
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 spec:
   replicas: 1
   selector:

--- a/http-add-on/templates/deployment-scaler.yaml
+++ b/http-add-on/templates/deployment-scaler.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{ tpl .Values.additionalLabels . | indent 4}}
   name: {{ .Chart.Name }}-external-scaler
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 spec:
   replicas: 1
   selector:

--- a/http-add-on/templates/rbac.yml
+++ b/http-add-on/templates/rbac.yml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}-leader-election-role
     {{- include "keda-addons-http.labels" . | indent 4 }}
   name: {{ .Chart.Name }}-leader-election-role
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 rules:
 - apiGroups:
   - ""
@@ -181,7 +181,7 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}-leader-election-binding
     {{- include "keda-addons-http.labels" . | indent 4 }}
   name: {{ .Chart.Name }}-leader-election-rolebinding
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -189,7 +189,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -209,7 +209,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -229,4 +229,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}

--- a/http-add-on/templates/svc-interceptor-admin.yaml
+++ b/http-add-on/templates/svc-interceptor-admin.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{ tpl .Values.additionalLabels . | indent 4}}
   name: "{{ .Chart.Name }}-{{ .Values.interceptor.admin.service }}"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 spec:
   ports:
   - name: https

--- a/http-add-on/templates/svc-interceptor-proxy.yaml
+++ b/http-add-on/templates/svc-interceptor-proxy.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{ tpl .Values.additionalLabels . | indent 4}}
   name: "{{ .Chart.Name }}-{{ .Values.interceptor.proxy.service }}"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 spec:
   ports:
   - name: https

--- a/http-add-on/templates/svc-operator-metrics.yaml
+++ b/http-add-on/templates/svc-operator-metrics.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: {{ .Chart.Name }}-controller-manager-metrics-service
     {{- include "keda-addons-http.labels" . | indent 4 }}
   name: {{ .Chart.Name }}-controller-manager-metrics-service
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 spec:
   ports:
   - name: https

--- a/http-add-on/templates/svc-scaler.yaml
+++ b/http-add-on/templates/svc-scaler.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{ tpl .Values.additionalLabels . | indent 4}}
   name: "{{ .Chart.Name }}-{{ .Values.scaler.service }}"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 spec:
   ports:
   - name: grpc

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -1,6 +1,9 @@
 # Optionally declare a namespace via values
 # When using keda as a dependency set the value `keda.namespace` to control
-# which namespace keda will be installed in.
+# which namespace the HTTP Addon will be installed in.
+# If this is not set, the chart will use the namespace of the release.
+# If this is set, a new namespace will be created with this name
+# and the chart will use that.
 namespace:
 
 # Custom labels to add into metadata

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -1,3 +1,8 @@
+# Optionally declare a namespace via values
+# When using keda as a dependency set the value `keda.namespace` to control
+# which namespace keda will be installed in.
+namespace:
+
 # Custom labels to add into metadata
 additionalLabels: ""
 

--- a/keda/templates/00-namespace.yaml
+++ b/keda/templates/00-namespace.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.namespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+{{- end }}

--- a/keda/templates/01-serviceaccount.yaml
+++ b/keda/templates/01-serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
   {{- toYaml .Values.serviceAccount.annotations | nindent 6}}
   {{- end }}
   name: {{ .Values.serviceAccount.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 {{- end -}}

--- a/keda/templates/11-keda-clusterrolebinding.yaml
+++ b/keda/templates/11-keda-clusterrolebinding.yaml
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 {{- end -}}

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.operator.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
   labels:
     app: {{ .Values.operator.name }}
     name: {{ .Values.operator.name }}

--- a/keda/templates/13-keda-poddisruptionbudget.yaml
+++ b/keda/templates/13-keda-poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
   name: {{ .Values.operator.name }}
   labels:
     app.kubernetes.io/name: {{ .Values.serviceAccount.name }}

--- a/keda/templates/21-metrics-clusterrolebinding.yaml
+++ b/keda/templates/21-metrics-clusterrolebinding.yaml
@@ -13,7 +13,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -30,7 +30,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.operator.name }}-metrics-apiserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
   labels:
     app: {{ .Values.operator.name }}-metrics-apiserver
     app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver

--- a/keda/templates/23-metrics-service.yaml
+++ b/keda/templates/23-metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver
     {{- include "keda.labels" . | indent 4 }}
   name: {{ .Values.operator.name }}-metrics-apiserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
   annotations:
   {{- range $key, $value := .Values.service.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/keda/templates/24-metrics-apiservice.yaml
+++ b/keda/templates/24-metrics-apiservice.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   service:
     name: {{ .Values.operator.name }}-metrics-apiserver
-    namespace: {{ .Release.Namespace }}
+  # namespace: {{ default .Release.Namespace .Values.namespace }}
   group: external.metrics.k8s.io
   version: v1beta1
   insecureSkipTLSVerify: true

--- a/keda/templates/25-metrics-poddisruptionbudget.yaml
+++ b/keda/templates/25-metrics-poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
   name: {{ .Values.operator.name }}-metrics-apiserver
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -2,6 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Optionally declare a namespace via values
+# When using keda as a dependency set the value `keda.namespace` to control
+# which namespace keda will be installed in.
+namespace:
+
 image:
   keda:
     repository: ghcr.io/kedacore/keda

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -5,6 +5,9 @@
 # Optionally declare a namespace via values
 # When using keda as a dependency set the value `keda.namespace` to control
 # which namespace keda will be installed in.
+# If this is not set, the chart will use the namespace of the release.
+# If this is set, a new namespace will be created with this name
+# and the chart will use that.
 namespace:
 
 image:


### PR DESCRIPTION
Adds an _optional_ `namespace` variable which can be specified so that keda can be installed as a helm dependency.

## Scenario 1: Set namespace via `.Release.namespace`
```sh
helm install keda1 keda --create-namespace --namespace keda1 --dry-run > withns.yaml
```
![Screen Shot 2021-11-16 at 9 32 51 AM](https://user-images.githubusercontent.com/10974/142018639-57c7978b-a419-4d91-a9bf-7350e1524d9d.png)

[withns.yaml.zip](https://github.com/kedacore/charts/files/7547911/withns.yaml.zip)

## Scenario 2: Set namespace via `.Values.namespace`
```sh
helm install keda1 keda --set namespace=keda2 --dry-run > setns.yaml
```
![Screen Shot 2021-11-16 at 9 38 21 AM](https://user-images.githubusercontent.com/10974/142018634-0fd7eccf-5464-4ffa-b267-ef64ba21a903.png)

[setns.yaml.zip](https://github.com/kedacore/charts/files/7547916/setns.yaml.zip)

## Conclusion

This will now enable a parent chart to add keda as a dependency:

```yaml
# Chart.yaml
- name: keda
  version: "2.4.0"
  repository: https://kedacore.github.io/charts
```
```yaml
# values.yaml
keda:
  namespace: keda
```

## Optional

If we set the value to be `namespace: keda` by default it would always go into the keda namespace but it would have the downside of ignoring the `--namespace` parameter which would be a breaking change.


### Checklist

- [ ] [Read more about how you can contribute in our contribution guide](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md)
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] README is updated with new configuration values *(if applicable)*

Fixes #196 