### PR TITLE
test: Deploy Helm charts on N+5 different Kubernetes versions

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   lint-helm-3-x:
+    name: Lint Helm Chart
     runs-on: ubuntu-latest
     steps:
     - name: Check out code

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -29,7 +29,27 @@ jobs:
       run: helm lint keda
 
   deploy-helm-3-x:
+    name: Deploy to Kubernetes ${{ matrix.kubernetesVersion }}
+    needs: lint-helm-3-x
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Images are defined on every Kind release
+          # See https://github.com/kubernetes-sigs/kind/releases
+        - kubernetesVersion: v1.22
+          kindImage: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+        - kubernetesVersion: v1.21
+          kindImage: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        - kubernetesVersion: v1.20
+          kindImage: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+        - kubernetesVersion: v1.19
+          kindImage: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+        - kubernetesVersion: v1.18
+          kindImage: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
+        - kubernetesVersion: v1.17
+          kindImage: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
     steps:
     - name: Check out code
       uses: actions/checkout@v2
@@ -37,18 +57,24 @@ jobs:
     - name: Helm install
       uses: Azure/setup-helm@v1
       
-    - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1.0.0
+    - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
+      uses: helm/kind-action@v1.2.0
+      with:
+        node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version
       run: |
         kubectl version
 
+    - name: Show Kubernetes nodes
+      run: |
+        kubectl get nodes -o wide
+
     - name: Show Helm version
       run: |
         helm version
 
-    - name: Create keda namespace
+    - name: Create KEDA namespace
       run: kubectl create ns keda
 
     - name: Template Helm chart
@@ -56,6 +82,10 @@ jobs:
 
     - name: Install Helm chart
       run: helm install keda ./keda/ --namespace keda
+
+    - name: Show Kubernetes resources
+      run: kubectl get all --namespace keda
+      if: always()
 
     - name: Get all CRDs
       run: kubectl get crds -o wide
@@ -89,3 +119,4 @@ jobs:
 
     - name: Get our Nginx ScaledObject
       run: kubectl get scaledobjects/nginx-autoscaling -o wide
+      if: always()

--- a/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
+++ b/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
@@ -15,34 +15,90 @@ on:
       - external-scaler-azure-cosmos-db/**
 
 jobs:
+  lint-helm-3-x:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Helm install
+      uses: Azure/setup-helm@v1
+
+    - name: Lint 'Azure Cosmos DB external scaler' Helm chart
+      run: helm lint ./external-scaler-azure-cosmos-db/ --strict
+
+  deploy-helm-3-x:
+    name: Deploy to Kubernetes ${{ matrix.kubernetesVersion }}
+    needs: lint-helm-3-x
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Images are defined on every Kind release
+          # See https://github.com/kubernetes-sigs/kind/releases
+        - kubernetesVersion: v1.22
+          kindImage: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+        - kubernetesVersion: v1.21
+          kindImage: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        - kubernetesVersion: v1.20
+          kindImage: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+        - kubernetesVersion: v1.19
+          kindImage: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+        - kubernetesVersion: v1.18
+          kindImage: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
+        - kubernetesVersion: v1.17
+          kindImage: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
   verify-helm-chart:
     name: Verify Helm chart
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+    - name: Check out code
+      uses: actions/checkout@v2
 
-      - name: Setup Helm
-        uses: azure/setup-helm@v1
+    - name: Helm install
+      uses: Azure/setup-helm@v1
+      
+    - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
+      uses: helm/kind-action@v1.2.0
+      with:
+        node_image: ${{ matrix.kindImage }}
 
-      - name: Lint 'Azure Cosmos DB external scaler' Helm chart
-        run: helm lint ./external-scaler-azure-cosmos-db/ --strict
+    - name: Show Kubernetes version
+      run: |
+        kubectl version
 
-      - name: Show 'Azure Cosmos DB external scaler' Helm chart template
-        run: helm template test-release ./external-scaler-azure-cosmos-db/ --namespace test-namespace
+    - name: Show Kubernetes nodes
+      run: |
+        kubectl get nodes -o wide
 
-      - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.2.0
+    - name: Show Helm version
+      run: |
+        helm version
 
-      - name: Install 'Azure Cosmos DB external scaler' chart
-        run: helm install test-release ./external-scaler-azure-cosmos-db/ --namespace test-namespace --create-namespace --wait --timeout=2m
+    - name: Create KEDA namespace
+      run: kubectl create ns keda
 
-      - name: Get 'Azure Cosmos DB external scaler' service
-        run: kubectl get service external-scaler-azure-cosmos-db --namespace=test-namespace
+    - name: Template Helm chart
+      run: helm template test-release ./external-scaler-azure-cosmos-db/ --namespace test-namespace
 
-      - name: Get 'Azure Cosmos DB external scaler' deployment
-        run: kubectl get deployment external-scaler-azure-cosmos-db --namespace=test-namespace
+    - name: Install Helm chart
+      run: helm install test-release ./external-scaler-azure-cosmos-db/ --namespace test-namespace --create-namespace --wait --timeout=2m
 
-      - name: Uninstall 'Azure Cosmos DB external scaler' Helm chart
-        run: helm uninstall test-release --namespace test-namespace
+    - name: Show Kubernetes resources
+      run: kubectl get all --namespace keda
+      if: always()
+
+    - name: Get 'Azure Cosmos DB external scaler' service
+      run: kubectl get service external-scaler-azure-cosmos-db --namespace=test-namespace
+
+    - name: Get 'Azure Cosmos DB external scaler' deployment
+      run: kubectl get deployment external-scaler-azure-cosmos-db --namespace=test-namespace
+
+    - name: Uninstall 'Azure Cosmos DB external scaler' Helm chart
+      run: helm uninstall test-release --namespace test-namespace

--- a/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
+++ b/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
@@ -1,4 +1,4 @@
-name: Helm Chart CI (Azure Cosmos DB external scaler)
+name: Helm Chart CI (External Scalers - Azure Cosmos DB)
 
 on:
   push:
@@ -16,6 +16,7 @@ on:
 
 jobs:
   lint-helm-3-x:
+    name: Lint Helm Chart
     runs-on: ubuntu-latest
     steps:
     - name: Check out code

--- a/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
+++ b/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
@@ -54,14 +54,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-  verify-helm-chart:
-    name: Verify Helm chart
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-
     - name: Helm install
       uses: Azure/setup-helm@v1
       

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   lint-helm-3-x:
+    name: Lint Helm Chart
     runs-on: ubuntu-latest
     steps:
     - name: Check out code

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -29,7 +29,27 @@ jobs:
       run: helm lint http-add-on
 
   deploy-helm-3-x:
+    name: Deploy to Kubernetes ${{ matrix.kubernetesVersion }}
+    needs: lint-helm-3-x
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Images are defined on every Kind release
+          # See https://github.com/kubernetes-sigs/kind/releases
+        - kubernetesVersion: v1.22
+          kindImage: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+        - kubernetesVersion: v1.21
+          kindImage: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+        - kubernetesVersion: v1.20
+          kindImage: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+        - kubernetesVersion: v1.19
+          kindImage: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+        - kubernetesVersion: v1.18
+          kindImage: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
+        - kubernetesVersion: v1.17
+          kindImage: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
     steps:
     - name: Check out code
       uses: actions/checkout@v2
@@ -37,21 +57,27 @@ jobs:
     - name: Helm install
       uses: Azure/setup-helm@v1
 
-    - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1.0.0
+    - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
+      uses: helm/kind-action@v1.2.0
+      with:
+        node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version
       run: |
         kubectl version
 
+    - name: Show Kubernetes nodes
+      run: |
+        kubectl get nodes -o wide
+
     - name: Show Helm version
       run: |
         helm version
 
-    - name: Create keda namespace
+    - name: Create KEDA namespace
       run: kubectl create ns keda
 
-    - name: Install Keda chart
+    - name: Install KEDA chart
       run: helm install keda ./keda/ --namespace keda
 
     - name: Template Helm chart
@@ -59,6 +85,10 @@ jobs:
 
     - name: Install Helm chart
       run: helm install http-add-on ./http-add-on/ --namespace keda
+
+    - name: Show Kubernetes resources
+      run: kubectl get all --namespace keda
+      if: always()
 
     - name: Get all HTTPScaledObjects
       run: kubectl get httpscaledobjects


### PR DESCRIPTION
Deploy Helm charts on N+5 different Kubernetes versions to ensure we are handling feature usage correctly with respect to Kubernetes versions.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
