### PR TITLE
fix: add list and watch access for service accounts to cluster role

### DIFF
--- a/keda/templates/10-keda-clusterrole.yaml
+++ b/keda/templates/10-keda-clusterrole.yaml
@@ -28,6 +28,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - '*'
   resources:
   - '*'


### PR DESCRIPTION
Signed-off-by: tomasspi <tom-300@hotmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md
-->

Added `list` and `watch` access for service accounts to `keda-operator` cluster role.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/master/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- ~~README is updated with new configuration values *(if applicable)*~~

Relates to https://github.com/kedacore/keda/pull/2406
Relates to https://github.com/kedacore/keda/issues/2383
