### PR TITLE
Adding WATCH_NAMESPACE option to the HTTP Addon operator

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -90,6 +90,7 @@ their default values.
 | `images.kubeRbacProxy.tag`                                 | Image tag for the Kube RBAC Proxy image component | `v0.5.0` |
 | `additionalLabels`                                         | Additional labels to be applied to installed resources. Note that not all resources will receive these labels. | Nothing |
 | `crds.install`                                             | Whether to install the `HTTPScaledObject` [`CustomResourceDefinition`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) | `true` |
+| `operator.watchNamespace`                                  | The namespace to watch for new `HTTPScaledObject`s. Leave this blank (i.e. `""`) to tell the operator to watch all namespaces. | `""` |
 | `operator.pullPolicy`                                      | The image pull policy for the operator component | `Always` |
 | `operator.resources.limits.cpu`                            | The CPU resource limit for the operator component | `0.5` |
 | `operator.resources.limits.memory`                         | The memory resource limit for the operator component | `64Mi` |

--- a/http-add-on/templates/deployment-operator.yaml
+++ b/http-add-on/templates/deployment-operator.yaml
@@ -57,6 +57,8 @@ spec:
           value: "{{ .Values.interceptor.proxy.port }}"
         - name: KEDA_HTTP_OPERATOR_NAMESPACE
           value: "{{ .Release.Namespace }}"
+        - name: KEDA_HTTP_OPERATOR_WATCH_NAMESPACE
+          value: "{{ .Values.operator.watchNamespace }}"
 
         ports: 
         - containerPort: {{ .Values.operator.adminPort }}

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -7,6 +7,10 @@ crds:
 
 # operator-specific configuration values
 operator:
+  # the namespace to watch for new HTTPScaledObjects.
+  # leave this empty to tell the operator to watch in all
+  # namespaces
+  watchNamespace: ""
   # the image pull policy of the operator
   pullPolicy: Always
   # operator pod resource limits


### PR DESCRIPTION
https://github.com/kedacore/http-add-on/pull/269 introduces the option to run the HTTP Addon system in a mode that allows one installation to work across all namespaces. This PR exposes new configuration that the change introduces

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- ~A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*~
- [x] README is updated with new configuration values *(if applicable)*


