### PR TITLE
Fix indentation of ServiceAccount annotations

### DIFF
--- a/keda/templates/01-serviceaccount.yaml
+++ b/keda/templates/01-serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "keda.labels" . | indent 4 }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
-  {{- toYaml .Values.serviceAccount.annotations | nindent 6}}
+  {{- toYaml .Values.serviceAccount.annotations | nindent 4}}
   {{- end }}
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The indentation of this line is incorrect and setting a value for the service account annotations produces an invalid chart. Note that these values should be the same level as the "label" above.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Fixes #
