### PR TITLE
Add extra container args config for both keda operator and metric server

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -97,6 +97,8 @@ their default values.
 | `tolerations`                                              | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) | `{}` |
 | `affinity`                                                 | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) | `{}` |
 | `priorityClassName`                                        | Pod priority for KEDA Operator and Metrics Adapter ([docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)) | `` |
+| `extraArgs.keda`                                           | Additional KEDA Operator container arguments| `{}` |
+| `extraArgs.metricsAdapter`                                 | Additional Metrics Adapter container arguments | `{}` |
 | `env`                                                      | Additional environment variables that will be passed onto KEDA operator and metrics api service | `` |
 | `http.timeout` | The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them) | `` |
 | `service.annotations`                                      | Annotations to add the KEDA Metric Server service | `{}`                                        |

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -60,6 +60,9 @@ spec:
           - --leader-elect
           - "--zap-log-level={{ .Values.logging.operator.level }}"
           - "--zap-encoder={{ .Values.logging.operator.format }}"
+          {{- range $key, $value := .Values.extraArgs.keda }}
+          - --{{ $key }}={{ $value }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             httpGet:

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -89,6 +89,9 @@ spec:
           - --metrics-path={{ .Values.prometheus.metricServer.path }}
           {{- end }}
           - --v={{ .Values.logging.metricServer.level }}
+          {{- range $key, $value := .Values.extraArgs.metricsAdapter }}
+          - --{{ $key }}={{ $value }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.portHttpsTarget }}
               name: https

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -166,6 +166,11 @@ priorityClassName: ""
 http:
   timeout: 3000
 
+## Extra KEDA Operator and Metrics Adapter container arguments
+extraArgs:
+  keda: {}
+  metricsAdapter: {}
+
 ## Extra environment variables that will be passed onto KEDA operator and metrics api service
 env:
 # - name: ENV_NAME


### PR DESCRIPTION
Currently neither the KEDA operator nor the metric server accept extra arguments in the KEDA chart. However, in some cases we may need to set additional arguments like when [How do I run KEDA with readOnlyRootFilesystem=true ? as describe in the KEDA FAQs](https://keda.sh/docs/2.5/faq/) where [metric-server flags](https://github.com/kubernetes-sigs/metrics-server/blob/master/docs/command-line-flags.txt) are needed.

This change enables the user to be able to set additional container arguments when needed.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] README is updated with new configuration values *(if applicable)*
