### PR TITLE
HTTP Addon: Adding interceptor deployment name to scaler config

### DIFF
--- a/http-add-on/templates/deployment-scaler.yaml
+++ b/http-add-on/templates/deployment-scaler.yaml
@@ -50,6 +50,8 @@ spec:
         - containerPort: {{ .Values.scaler.grpcPort }}
           name: scaler-grpc
         env:
+        - name: KEDA_HTTP_SCALER_TARGET_ADMIN_DEPLOYMENT
+          value: "{{ .Chart.Name }}-interceptor"
         - name: KEDA_HTTP_SCALER_PORT
           value: "{{ .Values.scaler.grpcPort }}"
         - name: KEDA_HTTP_HEALTH_PORT


### PR DESCRIPTION
After https://github.com/kedacore/http-add-on/pull/386, the HTTP Addon's external scaler needs new configuration. This PR adds that new config.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Fixes #
