### PR TITLE
aggregate rbac for crds to default roles

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -93,6 +93,7 @@ their default values.
 | `podLabels.metricsAdapter`                                 | Pod labels for KEDA Metrics Adapter | `{}` |
 | `podLabels.webhooks`                                       | Pod labels for KEDA Admission webhooks | `{}` |
 | `rbac.create`                                              | Specifies whether RBAC should be used | `true`                                        |
+| `rbac.aggregateToDefaultRoles`                             | Specifies whether RBAC for CRDs should be [aggregated](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles) to default roles (view, edit, admin) | `false`                                        |
 | `serviceAccount.create`                                    | Specifies whether a service account should be created       | `true`                                        |
 | `serviceAccount.name`                                      | The name of the service account to use. If not set and create is true, a name is generated.      | `keda-operator` |
 | `serviceAccount.automountServiceAccountToken`              | Specifies whether created service account should automount API-Credentials | `true` |

--- a/keda/templates/manager/clusterrole.yaml
+++ b/keda/templates/manager/clusterrole.yaml
@@ -128,4 +128,52 @@ rules:
   - triggerauthentications/status
   verbs:
   - '*'
+{{- if .Values.rbac.aggregateToDefaultRoles }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keda:edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    app.kubernetes.io/name: {{ .Values.operator.name }}
+    {{- include "keda.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - keda.sh
+  resources:
+  - clustertriggerauthentications
+  - scaledjobs
+  - scaledobjects
+  - triggerauthentications
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keda:view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    app.kubernetes.io/name: {{ .Values.operator.name }}
+    {{- include "keda.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - keda.sh
+  resources:
+  - clustertriggerauthentications
+  - scaledjobs
+  - scaledobjects
+  - triggerauthentications
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}
 {{- end -}}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -125,6 +125,8 @@ podLabels:
 
 rbac:
   create: true
+  # Specifies whether RBAC for CRDs should be aggregated to default roles (view, edit, admin)
+  aggregateToDefaultRoles: false
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
this change adds ClusterRoles to aggregate rbac for
clustertriggerauthentications, scaledjobs, scaledobjects and
triggerauthentications to the kubernetes default roles view, edit and
admin via aggregation.
These ClusterRoles are optional and disabled by default. Set
rbac.aggregateToDefaultRoles to enable.



Signed-off-by: Till Adam <lxmail@web.de>

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*

Fixes #256
