### PR TITLE
AutomountServiceAccountToken property implemented

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -76,6 +76,7 @@ their default values.
 | `rbac.create`                                              | Specifies whether RBAC should be used | `true`                                        |
 | `serviceAccount.create`                                    | Specifies whether a service account should be created       | `true`                                        |
 | `serviceAccount.name`                                      | The name of the service account to use. If not set and create is true, a name is generated.      | `keda-operator` |
+| `serviceAccount.automountServiceAccountToken`              | Specifies whether created service account should automount API-Credentials | `true` |
 | `serviceAccount.annotations`                               | Annotations to add to the service account | `{}` |
 | `podIdentity.activeDirectory.identity`                     | Identity in Azure Active Directory to use for Azure pod identity | `` |
 | `grpcTLSCertsSecret`                                       | Name of the secret that will be mounted to the /grpccerts path on the Pod to communicate over TLS with external scaler(s) (recommended).  | ``|

--- a/keda/templates/01-serviceaccount.yaml
+++ b/keda/templates/01-serviceaccount.yaml
@@ -11,4 +11,5 @@ metadata:
   {{- end }}
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -39,6 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: true
       securityContext:
         {{- if .Values.podSecurityContext.operator }}
         {{- toYaml .Values.podSecurityContext.operator | nindent 8 }}

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -42,6 +42,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: true
       securityContext:
         {{- if .Values.podSecurityContext.metricServer }}
         {{- toYaml .Values.podSecurityContext.metricServer | nindent 8 }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -54,6 +54,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: keda-operator
+  # Specifies whether a service account should automount API-Credentials
+  automountServiceAccountToken: true
   # Annotations to add to the service account
   annotations: {}
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Added new property "automountServiceAccountToken" in ServiceAccounts and Deployments necessary for restricted environments.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*

Fixes #
