### PR TITLE
chore: Introduce Azure Workload Identity in CI matrix

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -39,6 +39,13 @@ jobs:
         enableAzureWorkloadIdentity: [false, true]
         kubernetesVersion: [v1.23, v1.22, v1.21, v1.20, v1.19, v1.18, v1.17]
         include:
+          # Azure Workload Identity
+        - enableAzureWorkloadIdentity: true
+          tenantId: contoso
+          clientId: ABC
+        - enableAzureWorkloadIdentity: false
+          tenantId: ""
+          clientId: ""
           # Images are defined on every Kind release
           # See https://github.com/kubernetes-sigs/kind/releases
         - kubernetesVersion: v1.23
@@ -83,10 +90,10 @@ jobs:
       run: kubectl create ns keda
 
     - name: Template Helm chart
-      run: helm template keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }}
+      run: helm template keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }} --set podIdentity.azureWorkload.tenantId=${{ matrix.tenantId }} --set podIdentity.azureWorkload.clientId=${{ matrix.clientId }}
 
     - name: Install Helm chart
-      run: helm install keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }}
+      run: helm install keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }} --set podIdentity.azureWorkload.tenantId=${{ matrix.tenantId }} --set podIdentity.azureWorkload.clientId=${{ matrix.clientId }}
 
     - name: Show Kubernetes resources
       run: kubectl get all --namespace keda

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -30,12 +30,13 @@ jobs:
       run: helm lint keda
 
   deploy-helm-3-x:
-    name: Deploy to Kubernetes ${{ matrix.kubernetesVersion }}
+    name: Deploy to Kubernetes ${{ matrix.kubernetesVersion }} (${{ (matrix.enableAzureWorkloadIdentity == true && 'With Azure Workload Identity') || 'Without Azure Workload Identity' }})
     needs: lint-helm-3-x
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        enableAzureWorkloadIdentity: [false, true]
         kubernetesVersion: [v1.23, v1.22, v1.21, v1.20, v1.19, v1.18, v1.17]
         include:
           # Images are defined on every Kind release
@@ -82,10 +83,10 @@ jobs:
       run: kubectl create ns keda
 
     - name: Template Helm chart
-      run: helm template keda ./keda/ --namespace keda
+      run: helm template keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }}
 
     - name: Install Helm chart
-      run: helm install keda ./keda/ --namespace keda
+      run: helm install keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }}
 
     - name: Show Kubernetes resources
       run: kubectl get all --namespace keda

--- a/keda/templates/01-serviceaccount.yaml
+++ b/keda/templates/01-serviceaccount.yaml
@@ -11,8 +11,8 @@ metadata:
   {{- if or .Values.podIdentity.azureWorkload.enabled .Values.serviceAccount.annotations }}
   annotations:
     {{- if .Values.podIdentity.azureWorkload.enabled }}
-    azure.workload.identity/client-id: {{ .Values.podIdentity.azureWorkload.clientId }}
-    azure.workload.identity/tenant-id: {{ .Values.podIdentity.azureWorkload.tenantId }}
+    azure.workload.identity/client-id: {{ .Values.podIdentity.azureWorkload.clientId | quote }}
+    azure.workload.identity/tenant-id: {{ .Values.podIdentity.azureWorkload.tenantId | quote }}
     azure.workload.identity/service-account-token-expiration: {{ .Values.podIdentity.azureWorkload.tokenExpiration | quote }}
     {{- end }}
     {{- if .Values.serviceAccount.annotations }}


### PR DESCRIPTION
Introduce Azure Workload Identity in CI matrix to ensure it renders correctly

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/keda/issues/2487
Relates to https://github.com/kedacore/charts/pull/263
