### PR TITLE
ci: Run CI against Kubernetes v1.17 -> v1.24

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: 1.3.0
+        version: 1.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -74,6 +74,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
+        version: 1.3.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         enableAzureWorkloadIdentity: [false, true]
-        kubernetesVersion: [v1.23, v1.22, v1.21, v1.20, v1.19, v1.18, v1.17]
+        kubernetesVersion: [v1.24, v1.23, v1.22, v1.21, v1.20, v1.19, v1.18, v1.17]
         include:
           # Azure Workload Identity
         - enableAzureWorkloadIdentity: true
@@ -48,18 +48,20 @@ jobs:
           clientId: ""
           # Images are defined on every Kind release
           # See https://github.com/kubernetes-sigs/kind/releases
+        - kubernetesVersion: v1.24
+          kindImage: kindest/node:v1.24.0@sha256:406fd86d48eaf4c04c7280cd1d2ca1d61e7d0d61ddef0125cb097bc7b82ed6a1
         - kubernetesVersion: v1.23
-          kindImage: kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+          kindImage: kindest/node:v1.23.6@sha256:1af0f1bee4c3c0fe9b07de5e5d3fafeb2eec7b4e1b268ae89fcab96ec67e8355
         - kubernetesVersion: v1.22
-          kindImage: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+          kindImage: kindest/node:v1.22.9@sha256:6e57a6b0c493c7d7183a1151acff0bfa44bf37eb668826bf00da5637c55b6d5e
         - kubernetesVersion: v1.21
-          kindImage: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          kindImage: kindest/node:v1.21.12@sha256:ae05d44cc636ee961068399ea5123ae421790f472c309900c151a44ee35c3e3e
         - kubernetesVersion: v1.20
-          kindImage: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+          kindImage: kindest/node:v1.20.15@sha256:a6ce604504db064c5e25921c6c0fffea64507109a1f2a512b1b562ac37d652f3
         - kubernetesVersion: v1.19
-          kindImage: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+          kindImage: kindest/node:v1.19.16@sha256:dec41184d10deca01a08ea548197b77dc99eeacb56ff3e371af3193c86ca99f4
         - kubernetesVersion: v1.18
-          kindImage: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
+          kindImage: kindest/node:v1.18.20@sha256:38a8726ece5d7867fb0ede63d718d27ce2d41af519ce68be5ae7fcca563537ed
         - kubernetesVersion: v1.17
           kindImage: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
     steps:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: 1.13.0
+        version: v1.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: v1.13.0
+        version: v0.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
+++ b/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: 1.13.0
+        version: v1.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
+++ b/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: 1.3.0
+        version: 1.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
+++ b/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: v1.13.0
+        version: v0.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
+++ b/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
@@ -35,22 +35,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetesVersion: [v1.23, v1.22, v1.21, v1.20, v1.19, v1.18, v1.17]
+        kubernetesVersion: [v1.24, v1.23, v1.22, v1.21, v1.20, v1.19, v1.18, v1.17]
         include:
           # Images are defined on every Kind release
           # See https://github.com/kubernetes-sigs/kind/releases
+        - kubernetesVersion: v1.24
+          kindImage: kindest/node:v1.24.0@sha256:406fd86d48eaf4c04c7280cd1d2ca1d61e7d0d61ddef0125cb097bc7b82ed6a1
         - kubernetesVersion: v1.23
-          kindImage: kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+          kindImage: kindest/node:v1.23.6@sha256:1af0f1bee4c3c0fe9b07de5e5d3fafeb2eec7b4e1b268ae89fcab96ec67e8355
         - kubernetesVersion: v1.22
-          kindImage: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+          kindImage: kindest/node:v1.22.9@sha256:6e57a6b0c493c7d7183a1151acff0bfa44bf37eb668826bf00da5637c55b6d5e
         - kubernetesVersion: v1.21
-          kindImage: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          kindImage: kindest/node:v1.21.12@sha256:ae05d44cc636ee961068399ea5123ae421790f472c309900c151a44ee35c3e3e
         - kubernetesVersion: v1.20
-          kindImage: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+          kindImage: kindest/node:v1.20.15@sha256:a6ce604504db064c5e25921c6c0fffea64507109a1f2a512b1b562ac37d652f3
         - kubernetesVersion: v1.19
-          kindImage: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+          kindImage: kindest/node:v1.19.16@sha256:dec41184d10deca01a08ea548197b77dc99eeacb56ff3e371af3193c86ca99f4
         - kubernetesVersion: v1.18
-          kindImage: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
+          kindImage: kindest/node:v1.18.20@sha256:38a8726ece5d7867fb0ede63d718d27ce2d41af519ce68be5ae7fcca563537ed
         - kubernetesVersion: v1.17
           kindImage: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
     steps:

--- a/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
+++ b/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
@@ -65,6 +65,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
+        version: 1.3.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: v1.13.0
+        version: v0.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: 1.3.0
+        version: 1.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
-        version: 1.13.0
+        version: v1.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -36,22 +36,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetesVersion: [v1.23, v1.22, v1.21, v1.20, v1.19, v1.18, v1.17]
+        kubernetesVersion: [v1.24, v1.22, v1.21, v1.20, v1.19, v1.18, v1.17]
         include:
           # Images are defined on every Kind release
           # See https://github.com/kubernetes-sigs/kind/releases
+        - kubernetesVersion: v1.24
+          kindImage: kindest/node:v1.24.0@sha256:406fd86d48eaf4c04c7280cd1d2ca1d61e7d0d61ddef0125cb097bc7b82ed6a1
         - kubernetesVersion: v1.23
-          kindImage: kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+          kindImage: kindest/node:v1.23.6@sha256:1af0f1bee4c3c0fe9b07de5e5d3fafeb2eec7b4e1b268ae89fcab96ec67e8355
         - kubernetesVersion: v1.22
-          kindImage: kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047
+          kindImage: kindest/node:v1.22.9@sha256:6e57a6b0c493c7d7183a1151acff0bfa44bf37eb668826bf00da5637c55b6d5e
         - kubernetesVersion: v1.21
-          kindImage: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          kindImage: kindest/node:v1.21.12@sha256:ae05d44cc636ee961068399ea5123ae421790f472c309900c151a44ee35c3e3e
         - kubernetesVersion: v1.20
-          kindImage: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+          kindImage: kindest/node:v1.20.15@sha256:a6ce604504db064c5e25921c6c0fffea64507109a1f2a512b1b562ac37d652f3
         - kubernetesVersion: v1.19
-          kindImage: kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
+          kindImage: kindest/node:v1.19.16@sha256:dec41184d10deca01a08ea548197b77dc99eeacb56ff3e371af3193c86ca99f4
         - kubernetesVersion: v1.18
-          kindImage: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c
+          kindImage: kindest/node:v1.18.20@sha256:38a8726ece5d7867fb0ede63d718d27ce2d41af519ce68be5ae7fcca563537ed
         - kubernetesVersion: v1.17
           kindImage: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
     steps:

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -66,6 +66,7 @@ jobs:
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0
       with:
+        version: 1.3.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version


### PR DESCRIPTION
Run CI against Kubernetes v1.17 -> v1.24

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

