### PR TITLE
fix: Change sample scaledobject version to 2.7

### DIFF
--- a/samples/nginx-scaledobject.yml
+++ b/samples/nginx-scaledobject.yml
@@ -37,6 +37,6 @@ spec:
   maxReplicaCount: 5
   triggers:
   - type: cpu
+    metricType: Utilization
     metadata:
-      type: Utilization
       value: "70"


### PR DESCRIPTION
Signed-off-by: Swalloow <swalloow.me@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

- Change sample scaledobject version to 2.7
- https://keda.sh/docs/2.7/scalers/cpu/

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] README is updated with new configuration values *(if applicable)*

Fixes #
