### PR TITLE
Remove metrics server Prometheus scrape accotations if podMonitor is enabled

### DIFF
--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- toYaml .Values.podLabels.metricsAdapter | nindent 8}}
         {{- end }}
       annotations:
-      {{- if .Values.prometheus.metricServer.enabled }}
+      {{- if and .Values.prometheus.metricServer.enabled ( not .Values.prometheus.metricServer.podMonitor.enabled ) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.metricServer.port | quote }}
         prometheus.io/path: {{ .Values.prometheus.metricServer.path }}


### PR DESCRIPTION
Remove metrics server Prometheus scrape accotations if podMonitor is enabled.

Signed-off-by: Max Howell <maxhowell24@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Fixes #277 
