### PR TITLE
Fix compatibility with Traefik

### DIFF
--- a/http-add-on/templates/svc-interceptor-proxy.yaml
+++ b/http-add-on/templates/svc-interceptor-proxy.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - name: https
+  - name: http
     port: {{ default 9091 .Values.interceptor.proxy.port }}
     targetPort: inter-proxy
   selector:


### PR DESCRIPTION
Signed-off-by: Kostas Christidis <kchristidis@atypon.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

### Changelog 
- fix compatibility with Traefik to address issue https://github.com/kedacore/charts/issues/282. use `http` instead of `https` for port name.


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Fixes https://github.com/kedacore/charts/issues/282
