### PR TITLE
[KEDA] add relabelling support

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -121,6 +121,7 @@ their default values.
 | `prometheus.metricServer.podMonitor.scrapeTimeout`         | Scraping timeout for metric server using podMonitor crd (prometheus operator) | ``
 | `prometheus.metricServer.podMonitor.namespace`             | Scraping namespace for metric server using podMonitor crd (prometheus operator) | ``
 | `prometheus.metricServer.podMonitor.additionalLabels`      | Additional labels to add for metric server using podMonitor crd (prometheus operator) | `{}`
+| `prometheus.metricServer.podMonitor.relabelings`           | List of expressions that define custom relabeling rules for metric server podMonitor crd (prometheus operator) | `[]`
 | `prometheus.operator.enabled`                              | Enable keda operator prometheus metrics expose | `false`
 | `prometheus.operator.port`                                 | HTTP port used for exposing keda operator prometheus metrics | `9022`
 | `prometheus.operator.path`                                 | Path used for exposing keda operator prometheus metrics | `/metrics`
@@ -133,6 +134,7 @@ their default values.
 | `prometheus.operator.prometheusRules.namespace`            | Scraping namespace for keda operator using prometheusRules crd (prometheus operator) | ``
 | `prometheus.operator.prometheusRules.additionalLabels`     | Additional labels to add for keda operator using prometheusRules crd (prometheus operator) | `{}`
 | `prometheus.operator.prometheusRules.alerts`               | Additional alerts to add for keda operator using prometheusRules crd (prometheus operator) | `[]`
+| `prometheus.operator.podMonitor.relabelings`               | List of expressions that define custom relabeling rules for keda operator podMonitor crd (prometheus operator) | `[]`
 | `volumes.keda.extraVolumes`                                | Extra volumes for keda deployment | `[]`
 | `volumes.keda.extraVolumeMounts`                           | Extra volume mounts for keda deployment | `[]`
 | `volumes.metricsApiServer.extraVolumes`                    | Extra volumes for metric server deployment | `[]`

--- a/keda/templates/14-keda-podmonitor.yaml
+++ b/keda/templates/14-keda-podmonitor.yaml
@@ -23,6 +23,10 @@ spec:
     {{- with .Values.prometheus.operator.podMonitor.scrapeTimeout }}
     scrapeTimeout: {{ . }}
     {{- end }}
+    {{- with .Values.prometheus.operator.podMonitor.relabelings }}
+    relabelings:
+{{ toYaml . | indent 4 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/keda/templates/26-metrics-podmonitor.yaml
+++ b/keda/templates/26-metrics-podmonitor.yaml
@@ -23,6 +23,10 @@ spec:
     {{- with .Values.prometheus.metricServer.podMonitor.scrapeTimeout }}
     scrapeTimeout: {{ . }}
     {{- end }}
+    {{- with .Values.prometheus.metricServer.podMonitor.relabelings }}
+    relabelings:
+{{ toYaml . | indent 4 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -227,6 +227,7 @@ prometheus:
       scrapeTimeout:
       namespace:
       additionalLabels: {}
+      relabelings: []
   operator:
     enabled: false
     port: 8080
@@ -238,6 +239,7 @@ prometheus:
       scrapeTimeout:
       namespace:
       additionalLabels: {}
+      relabelings: []
     prometheusRules:
       # Enables PrometheusRules creation for the Prometheus Operator
       enabled: false


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

This MR adds support to add relabelling expressions to both Operator & Metrics Server PodMonitor.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [X] README is updated with new configuration values *(if applicable)*

Fixes #
