### PR TITLE
Update 24-metrics-apiservice using RFC 1035 labels.yaml

### DIFF
--- a/keda/templates/24-metrics-apiservice.yaml
+++ b/keda/templates/24-metrics-apiservice.yaml
@@ -2,7 +2,7 @@ apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   labels:
-    app.kubernetes.io/name: v1beta1.external.metrics.k8s.io
+    app.kubernetes.io/name: v1beta1-external-metrics-k8s-io
     {{- include "keda.labels" . | indent 4 }}
   name: v1beta1.external.metrics.k8s.io
 spec:


### PR DESCRIPTION
This is against the RFC 1035 Label Names Kubernetes specification to have dot notation. 

Signed-off-by: sheperdsonbrown <sheperdsonbrown@users.noreply.github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [ ] README is updated with new configuration values *(if applicable)*

Fixes #
