### PR TITLE
Add Leader Election Lease Options

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -106,7 +106,10 @@ their default values.
 | `extraArgs.keda`                                           | Additional KEDA Operator container arguments| `{}` |
 | `extraArgs.metricsAdapter`                                 | Additional Metrics Adapter container arguments | `{}` |
 | `env`                                                      | Additional environment variables that will be passed onto KEDA operator and metrics api service | `` |
-| `http.timeout` | The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them) | `` |
+| `http.timeout` | The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them) | `3000` |
+| `leaderElection.leaseDuration`                             | The duration that non-leader KEDA Operator candidates will wait to force acquire leadership. | `` |
+| `leaderElection.renewDeadline`                             | The duration that the acting control plane will retry refreshing KEDA Operator leadership before giving up. | `` |
+| `leaderElection.retryPeriod`                               | The duration KEDA Operators should wait between leadership acquisition attempts. | `` |
 | `service.annotations`                                      | Annotations to add the KEDA Metric Server service | `{}`                                        |
 | `service.portHttp`                                         | Service HTTP port for KEDA Metric Server service | `80`                                        |
 | `service.portHttpTarget`                                   | Service HTTP port for KEDA Metric Server container | `8080`                                        |

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -93,6 +93,18 @@ spec:
             - name: KEDA_HTTP_DEFAULT_TIMEOUT
               value: {{ .Values.http.timeout | quote }}
             {{- end }}
+            {{- if .Values.leaderElection.leaseDuration }}
+            - name: KEDA_LEADER_ELECTION_LEASE_DURATION
+              value: {{ .Values.leaderElection.leaseDuration | quote }}
+            {{- end }}
+            {{- if .Values.leaderElection.renewDeadline }}
+            - name: KEDA_LEADER_ELECTION_RENEW_DEADLINE
+              value: {{ .Values.leaderElection.renewDeadline | quote }}
+            {{- end }}
+            {{- if .Values.leaderElection.retryPeriod }}
+            - name: KEDA_LEADER_ELECTION_RETRY_PERIOD
+              value: {{ .Values.leaderElection.retryPeriod | quote }}
+            {{- end }}
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 -}}
             {{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -33,7 +33,7 @@ podDisruptionBudget: {}
   # operator:
   #   minAvailable: 1
   #   maxUnavailable: 1
-  # metricServer: 
+  # metricServer:
   #   minAvailable: 1
   #   maxUnavailable: 1
 
@@ -193,6 +193,13 @@ priorityClassName: ""
 ## reasonable default
 http:
   timeout: 3000
+
+# KEDA Operator leader election leasing options. Optional.
+# If specified, should be a duration (e.g. '300ms' or '10s')
+leaderElection:
+  leaseDuration:
+  renewDeadline:
+  retryPeriod:
 
 ## Extra KEDA Operator and Metrics Adapter container arguments
 extraArgs:


### PR DESCRIPTION
Add new options for configuring the leader election lease under the element `leaderElection`, including:
  - `leaseDuration`
  - `renewDeadline`
  - `retryPeriod`

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [X] README is updated with new configuration values *(if applicable)*

Fixes https://github.com/kedacore/keda/issues/2836
