### PR TITLE
feat(keda): add deployment update strategy

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -70,6 +70,8 @@ their default values.
 | `additionalLabels`                                         | Additional labels to apply to KEDA workloads | `{}` |
 | `podAnnotations.keda`                                      | Pod annotations for KEDA operator | `{}` |
 | `podAnnotations.metricsAdapter`                            | Pod annotations for KEDA Metrics Adapter | `{}` |
+| `upgradeStrategy.operator`                                 | Capability to configure [Deployment upgrade strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) for operator      | `{}` |
+| `upgradeStrategy.metricsApiServer`                         | Capability to configure [Deployment upgrade strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) for Metrics Api Server      | `{}` |
 | `podDisruptionBudget.operator`                                      | Capability to configure [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)       | `{}` |
 | `podDisruptionBudget.metricServer`                                      | Capability to configure [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)       | `{}` |
 | `podLabels.keda`                                           | Pod labels for KEDA operator | `{}` |

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- include "keda.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.operator.replicaCount}}
+  {{- with .Values.upgradeStrategy.operator }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.operator.name }}

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- include "keda.labels" . | indent 4 }}
 spec:
   replicas: 1
+  {{- with .Values.upgradeStrategy.metricsApiServer }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.operator.name }}-metrics-apiserver

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -29,6 +29,18 @@ metricsServer:
   dnsPolicy: ClusterFirst
   useHostNetwork: false
 
+upgradeStrategy:
+  operator: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 1
+    #   maxSurge: 1
+  metricsApiServer: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 1
+    #   maxSurge: 1
+
 podDisruptionBudget: {}
   # operator:
   #   minAvailable: 1


### PR DESCRIPTION
Signed-off-by: Zadkiel Aharonian <hello@zadkiel.fr>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Add `upgradeStategy` field to the values that maps to the `Deployment.spec.strategy` field.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*

Fixes https://github.com/kedacore/charts/issues/293
