### PR TITLE
feat: add v1 PodDisruptionBudget

### DIFF
--- a/keda/templates/13-keda-poddisruptionbudget.yaml
+++ b/keda/templates/13-keda-poddisruptionbudget.yaml
@@ -1,5 +1,9 @@
 {{- if or (or .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable)  .Values.podDisruptionBudget.operator }}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Use v1 PodDisruptionBudget if supported (1.21+) otherwise use v1beta.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] N/A - A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] N/A - README is updated with new configuration values *(if applicable)*

Fixes #281 
