### PR TITLE
feat: add seccompProfile

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -172,13 +172,19 @@ securityContext:
       - ALL
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
+    ## Add explicit seccompProfile type for Kubernetes 1.19+
+    # seccompProfile:
+    #   type: RuntimeDefault
   metricServer:
     capabilities:
       drop:
       - ALL
     allowPrivilegeEscalation: false
-    ## Metrics server needs to write the self-signed cert so it's not possible set this
+    ## Metrics server needs to write the self-signed cert. See FAQ for discussion of options.
     # readOnlyRootFilesystem: true
+    ## Add explicit seccompProfile type for Kubernetes 1.19+
+    # seccompProfile:
+    #   type: RuntimeDefault
 
 podSecurityContext:
   operator:

--- a/keda/README.md
+++ b/keda/README.md
@@ -172,9 +172,8 @@ securityContext:
       - ALL
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
-    ## Add explicit seccompProfile type for Kubernetes 1.19+
-    # seccompProfile:
-    #   type: RuntimeDefault
+    seccompProfile:
+      type: RuntimeDefault
   metricServer:
     capabilities:
       drop:
@@ -182,9 +181,8 @@ securityContext:
     allowPrivilegeEscalation: false
     ## Metrics server needs to write the self-signed cert. See FAQ for discussion of options.
     # readOnlyRootFilesystem: true
-    ## Add explicit seccompProfile type for Kubernetes 1.19+
-    # seccompProfile:
-    #   type: RuntimeDefault
+    seccompProfile:
+      type: RuntimeDefault
 
 podSecurityContext:
   operator:

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -153,9 +153,8 @@ securityContext:
       - ALL
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
-    ## Add explicit seccompProfile type for Kubernetes 1.19+
-    # seccompProfile:
-    #   type: RuntimeDefault
+    seccompProfile:
+      type: RuntimeDefault
   metricServer:
     capabilities:
       drop:
@@ -163,9 +162,8 @@ securityContext:
     allowPrivilegeEscalation: false
     ## Metrics server needs to write the self-signed cert. See FAQ for discussion of options.
     # readOnlyRootFilesystem: true
-    ## Add explicit seccompProfile type for Kubernetes 1.19+
-    # seccompProfile:
-    #   type: RuntimeDefault
+    seccompProfile:
+      type: RuntimeDefault
 
 podSecurityContext:
   operator:

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -153,13 +153,19 @@ securityContext:
       - ALL
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
+    ## Add explicit seccompProfile type for Kubernetes 1.19+
+    # seccompProfile:
+    #   type: RuntimeDefault
   metricServer:
     capabilities:
       drop:
       - ALL
     allowPrivilegeEscalation: false
-    ## Metrics server needs to write the self-signed cert so it's not possible set this
+    ## Metrics server needs to write the self-signed cert. See FAQ for discussion of options.
     # readOnlyRootFilesystem: true
+    ## Add explicit seccompProfile type for Kubernetes 1.19+
+    # seccompProfile:
+    #   type: RuntimeDefault
 
 podSecurityContext:
   operator:


### PR DESCRIPTION
Add/update securityContext configs:
* seccompProfile.type RuntimeDefault is needed for compliance with restricted policies in Kubernetes 1.19+
* Updated comment in metrics Deployment and README regarding readOnlyRootFilesystem

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Fixes #306 
Fixes #301 
