### PR TITLE
fix: allow user to configure metrics API server port

### DIFF
--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -87,6 +87,7 @@ spec:
             {{- end }}
           args:
           - /usr/local/bin/keda-adapter
+          - --port={{ .Values.service.portHttpTarget }}
           - --secure-port={{ .Values.service.portHttpsTarget }}
           - --logtostderr=true
           {{- if .Values.prometheus.metricServer.enabled }}


### PR DESCRIPTION
Signed-off-by: Benjamin Berman <>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->



### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Relates to https://github.com/kedacore/keda/issues/3576
