### PR TITLE
chore(core): Remove support for Kubernetes v1.17, v1.18 & v1.19

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         enableAzureWorkloadIdentity: [false, true]
-        kubernetesVersion: [v1.24, v1.23, v1.22, v1.21, v1.20, v1.19, v1.18, v1.17]
+        kubernetesVersion: [v1.24, v1.23, v1.22, v1.21, v1.20]
         include:
           # Azure Workload Identity
         - enableAzureWorkloadIdentity: true
@@ -58,12 +58,6 @@ jobs:
           kindImage: kindest/node:v1.21.12@sha256:ae05d44cc636ee961068399ea5123ae421790f472c309900c151a44ee35c3e3e
         - kubernetesVersion: v1.20
           kindImage: kindest/node:v1.20.15@sha256:a6ce604504db064c5e25921c6c0fffea64507109a1f2a512b1b562ac37d652f3
-        - kubernetesVersion: v1.19
-          kindImage: kindest/node:v1.19.16@sha256:dec41184d10deca01a08ea548197b77dc99eeacb56ff3e371af3193c86ca99f4
-        - kubernetesVersion: v1.18
-          kindImage: kindest/node:v1.18.20@sha256:38a8726ece5d7867fb0ede63d718d27ce2d41af519ce68be5ae7fcca563537ed
-        - kubernetesVersion: v1.17
-          kindImage: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -4,7 +4,7 @@ description: Event-based autoscaler for workloads on Kubernetes
 
 # Specify the Kubernetes version range that we support.
 # We allow pre-release versions for cloud-specific Kubernetes versions such as  v1.21.5-gke.1302 or v1.18.9-eks-d1db3c
-kubeVersion: ">=v1.17.0-0"
+kubeVersion: ">=v1.19.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.

--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -4,7 +4,7 @@ description: Event-based autoscaler for workloads on Kubernetes
 
 # Specify the Kubernetes version range that we support.
 # We allow pre-release versions for cloud-specific Kubernetes versions such as  v1.21.5-gke.1302 or v1.18.9-eks-d1db3c
-kubeVersion: ">=v1.19.0-0"
+kubeVersion: ">=v1.20.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.


### PR DESCRIPTION
Remove support for Kubernetes v1.17, v1.18 & v1.19 as per [our support policy](https://github.com/kedacore/governance/blob/main/SUPPORT.md#kubernetes-support).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
