### PR TITLE
Remove unsuported K8s versions from HTTP-Add-on CI

### DIFF
--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -40,22 +40,12 @@ jobs:
         include:
           # Images are defined on every Kind release
           # See https://github.com/kubernetes-sigs/kind/releases
+        - kubernetesVersion: v1.25
+          kindImage: kindest/node:v1.25.0@sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf
         - kubernetesVersion: v1.24
           kindImage: kindest/node:v1.24.0@sha256:406fd86d48eaf4c04c7280cd1d2ca1d61e7d0d61ddef0125cb097bc7b82ed6a1
         - kubernetesVersion: v1.23
           kindImage: kindest/node:v1.23.6@sha256:1af0f1bee4c3c0fe9b07de5e5d3fafeb2eec7b4e1b268ae89fcab96ec67e8355
-        - kubernetesVersion: v1.22
-          kindImage: kindest/node:v1.22.9@sha256:6e57a6b0c493c7d7183a1151acff0bfa44bf37eb668826bf00da5637c55b6d5e
-        - kubernetesVersion: v1.21
-          kindImage: kindest/node:v1.21.12@sha256:ae05d44cc636ee961068399ea5123ae421790f472c309900c151a44ee35c3e3e
-        - kubernetesVersion: v1.20
-          kindImage: kindest/node:v1.20.15@sha256:a6ce604504db064c5e25921c6c0fffea64507109a1f2a512b1b562ac37d652f3
-        - kubernetesVersion: v1.19
-          kindImage: kindest/node:v1.19.16@sha256:dec41184d10deca01a08ea548197b77dc99eeacb56ff3e371af3193c86ca99f4
-        - kubernetesVersion: v1.18
-          kindImage: kindest/node:v1.18.20@sha256:38a8726ece5d7867fb0ede63d718d27ce2d41af519ce68be5ae7fcca563537ed
-        - kubernetesVersion: v1.17
-          kindImage: kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -54,9 +54,8 @@ jobs:
       uses: Azure/setup-helm@v1
 
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
-      uses: helm/kind-action@v1.2.0
+      uses: helm/kind-action@main
       with:
-        version: v0.13.0
         node_image: ${{ matrix.kindImage }}
 
     - name: Show Kubernetes version


### PR DESCRIPTION
Signed-off-by: Jorge Turrado Ferrero <Jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

The HTTP Add-on uses KEDA chart to install KEDA, so tested versions should match with KEDA supported versions

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
