### PR TITLE
Added support for AWS IRSA in helm chart

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -89,11 +89,11 @@ their default values.
 | `podIdentity.azureWorkload.enabled`                        | Specifies whether [Azure Workload Identity](https://azure.github.io/azure-workload-identity/) is to be enabled or not. ([docs](https://keda.sh/docs/concepts/authentication/#azure-workload-identity)) | `false` |
 | `podIdentity.azureWorkload.tenantId`                       | Id Azure Active Directory Tenant to use for authentication with for Azure Workload Identity. ([docs](https://keda.sh/docs/concepts/authentication/#azure-workload-identity)) | `` |
 | `podIdentity.azureWorkload.tokenExpiration`                | Duration in seconds to automatically expire tokens for the service account. ([docs](https://keda.sh/docs/concepts/authentication/#azure-workload-identity)) | `3600` |
-| `podIdentity.irsa.audience`                                | Sets the token audience for IRSA. | `sts.amazonaws.com` |
-| `podIdentity.irsa.enabled`                                 | Specifies whether [AWS IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) is to be enabled or not. | `false` |
-| `podIdentity.irsa.roleArn`                                 | ARN of an IRSA IAM role with a web identity provider to use for authentication via STS. | `` |
-| `podIdentity.irsa.stsRegionalEndpoints`                    | Sets the use of an STS regional endpoint instead of global. Recommended to use regional endpoint in almost all cases. | `true` |
-| `podIdentity.irsa.tokenExpiration`                         | Duration in seconds to automatically expire tokens for the service account. | `86400` |
+| `podIdentity.aws.irsa.audience`                            | Sets the token audience for IRSA. | `sts.amazonaws.com` |
+| `podIdentity.aws.irsa.enabled`                             | Specifies whether [AWS IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) is to be enabled or not. | `false` |
+| `podIdentity.aws.irsa.roleArn`                             | ARN of an IRSA IAM role with a web identity provider to use for authentication via STS. | `` |
+| `podIdentity.aws.irsa.stsRegionalEndpoints`                | Sets the use of an STS regional endpoint instead of global. Recommended to use regional endpoint in almost all cases. | `true` |
+| `podIdentity.aws.irsa.tokenExpiration`                     | Duration in seconds to automatically expire tokens for the service account. | `86400` |
 | `grpcTLSCertsSecret`                                       | Name of the secret that will be mounted to the /grpccerts path on the Pod to communicate over TLS with external scaler(s) (recommended).  | ``|
 | `hashiCorpVaultTLS`                                        | Name of the secret that will be mounted to the /vault path on the Pod to communicate over TLS with HashiCorp Vault (recommended). | `` |
 | `logging.operator.level`                                   | Logging level for KEDA Operator. Allowed values are 'debug', 'info' & 'error'. | `info`                                        |

--- a/keda/README.md
+++ b/keda/README.md
@@ -89,6 +89,11 @@ their default values.
 | `podIdentity.azureWorkload.enabled`                        | Specifies whether [Azure Workload Identity](https://azure.github.io/azure-workload-identity/) is to be enabled or not. ([docs](https://keda.sh/docs/concepts/authentication/#azure-workload-identity)) | `false` |
 | `podIdentity.azureWorkload.tenantId`                       | Id Azure Active Directory Tenant to use for authentication with for Azure Workload Identity. ([docs](https://keda.sh/docs/concepts/authentication/#azure-workload-identity)) | `` |
 | `podIdentity.azureWorkload.tokenExpiration`                | Duration in seconds to automatically expire tokens for the service account. ([docs](https://keda.sh/docs/concepts/authentication/#azure-workload-identity)) | `3600` |
+| `podIdentity.irsa.audience`                                | Sets the token audience for IRSA. | `sts.amazonaws.com` |
+| `podIdentity.irsa.enabled`                                 | Specifies whether [AWS IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) is to be enabled or not. | `false` |
+| `podIdentity.irsa.roleArn`                                 | ARN of an IRSA IAM role with a web identity provider to use for authentication via STS. | `` |
+| `podIdentity.irsa.stsRegionalEndpoints`                    | Sets the use of an STS regional endpoint instead of global. Recommended to use regional endpoint in almost all cases. | `true` |
+| `podIdentity.irsa.tokenExpiration`                         | Duration in seconds to automatically expire tokens for the service account. | `86400` |
 | `grpcTLSCertsSecret`                                       | Name of the secret that will be mounted to the /grpccerts path on the Pod to communicate over TLS with external scaler(s) (recommended).  | ``|
 | `hashiCorpVaultTLS`                                        | Name of the secret that will be mounted to the /vault path on the Pod to communicate over TLS with HashiCorp Vault (recommended). | `` |
 | `logging.operator.level`                                   | Logging level for KEDA Operator. Allowed values are 'debug', 'info' & 'error'. | `info`                                        |

--- a/keda/templates/01-serviceaccount.yaml
+++ b/keda/templates/01-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     azure.workload.identity/use: {{ .Values.podIdentity.azureWorkload.enabled | quote }}
     {{- end }}
     {{- include "keda.labels" . | indent 4 }}
-  {{- if or .Values.podIdentity.azureWorkload.enabled .Values.podIdentity.irsa.enabled .Values.serviceAccount.annotations }}
+  {{- if or .Values.podIdentity.azureWorkload.enabled .Values.podIdentity.aws.irsa.enabled .Values.serviceAccount.annotations }}
   annotations:
     {{- if .Values.podIdentity.azureWorkload.enabled }}
     {{- if .Values.podIdentity.azureWorkload.clientId }}
@@ -19,17 +19,17 @@ metadata:
     {{- end }}
     azure.workload.identity/service-account-token-expiration: {{ .Values.podIdentity.azureWorkload.tokenExpiration | quote }}
     {{- end }}
-    {{- if .Values.podIdentity.irsa.enabled }}
-    {{- if .Values.podIdentity.irsa.audience }}
-    eks.amazonaws.com/audience: {{ .Values.podIdentity.irsa.audience | quote }}
+    {{- if .Values.podIdentity.aws.irsa.enabled }}
+    {{- if .Values.podIdentity.aws.irsa.audience }}
+    eks.amazonaws.com/audience: {{ .Values.podIdentity.aws.irsa.audience | quote }}
     {{- end }}
-    {{- if .Values.podIdentity.irsa.roleArn }}
-    eks.amazonaws.com/role-arn: {{ .Values.podIdentity.irsa.roleArn | quote }}
+    {{- if .Values.podIdentity.aws.irsa.roleArn }}
+    eks.amazonaws.com/role-arn: {{ .Values.podIdentity.aws.irsa.roleArn | quote }}
     {{- end }}
-    {{- if .Values.podIdentity.irsa.stsRegionalEndpoints }}
-    eks.amazonaws.com/sts-regional-endpoints: {{ .Values.podIdentity.irsa.stsRegionalEndpoints | quote }}
+    {{- if .Values.podIdentity.aws.irsa.stsRegionalEndpoints }}
+    eks.amazonaws.com/sts-regional-endpoints: {{ .Values.podIdentity.aws.irsa.stsRegionalEndpoints | quote }}
     {{- end }}
-    eks.amazonaws.com/token-expiration: {{ .Values.podIdentity.irsa.tokenExpiration | quote }}
+    eks.amazonaws.com/token-expiration: {{ .Values.podIdentity.aws.irsa.tokenExpiration | quote }}
     {{- end }}
     {{- if .Values.serviceAccount.annotations }}
     {{- toYaml .Values.serviceAccount.annotations | nindent 4}}

--- a/keda/templates/01-serviceaccount.yaml
+++ b/keda/templates/01-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     azure.workload.identity/use: {{ .Values.podIdentity.azureWorkload.enabled | quote }}
     {{- end }}
     {{- include "keda.labels" . | indent 4 }}
-  {{- if or .Values.podIdentity.azureWorkload.enabled .Values.serviceAccount.annotations }}
+  {{- if or .Values.podIdentity.azureWorkload.enabled .Values.podIdentity.irsa.enabled .Values.serviceAccount.annotations }}
   annotations:
     {{- if .Values.podIdentity.azureWorkload.enabled }}
     {{- if .Values.podIdentity.azureWorkload.clientId }}
@@ -18,6 +18,18 @@ metadata:
     azure.workload.identity/tenant-id: {{ .Values.podIdentity.azureWorkload.tenantId | quote }}
     {{- end }}
     azure.workload.identity/service-account-token-expiration: {{ .Values.podIdentity.azureWorkload.tokenExpiration | quote }}
+    {{- end }}
+    {{- if .Values.podIdentity.irsa.enabled }}
+    {{- if .Values.podIdentity.irsa.audience }}
+    eks.amazonaws.com/audience: {{ .Values.podIdentity.irsa.audience | quote }}
+    {{- end }}
+    {{- if .Values.podIdentity.irsa.roleArn }}
+    eks.amazonaws.com/role-arn: {{ .Values.podIdentity.irsa.roleArn | quote }}
+    {{- end }}
+    {{- if .Values.podIdentity.irsa.stsRegionalEndpoints }}
+    eks.amazonaws.com/sts-regional-endpoints: {{ .Values.podIdentity.irsa.stsRegionalEndpoints | quote }}
+    {{- end }}
+    eks.amazonaws.com/token-expiration: {{ .Values.podIdentity.irsa.tokenExpiration | quote }}
     {{- end }}
     {{- if .Values.serviceAccount.annotations }}
     {{- toYaml .Values.serviceAccount.annotations | nindent 4}}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -116,6 +116,22 @@ podIdentity:
     # Set to the value of the service account token expiration duration.
     # This will be set as an annotation on the KEDA service account.
     tokenExpiration: 3600
+  irsa:
+    # Set to true to enable AWS IAM Roles for Service Accounts (IRSA).
+    enabled: false
+    # Sets the token audience for IRSA.
+    # This will be set as an annotation on the KEDA service account.
+    audience: "sts.amazonaws.com"
+    # Set to the value of the ARN of an IAM role with a web identity provider.
+    # This will be set as an annotation on the KEDA service account.
+    roleArn: ""
+    # Sets the use of an STS regional endpoint instead of global. 
+    # Recommended to use regional endpoint in almost all cases.
+    # This will be set as an annotation on the KEDA service account.
+    stsRegionalEndpoints: "true"
+    # Set to the value of the service account token expiration duration.
+    # This will be set as an annotation on the KEDA service account.
+    tokenExpiration: 86400
 
 # Set this if you are using an external scaler and want to communicate
 # over TLS (recommended). This variable holds the name of the secret that

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -116,22 +116,23 @@ podIdentity:
     # Set to the value of the service account token expiration duration.
     # This will be set as an annotation on the KEDA service account.
     tokenExpiration: 3600
-  irsa:
-    # Set to true to enable AWS IAM Roles for Service Accounts (IRSA).
-    enabled: false
-    # Sets the token audience for IRSA.
-    # This will be set as an annotation on the KEDA service account.
-    audience: "sts.amazonaws.com"
-    # Set to the value of the ARN of an IAM role with a web identity provider.
-    # This will be set as an annotation on the KEDA service account.
-    roleArn: ""
-    # Sets the use of an STS regional endpoint instead of global. 
-    # Recommended to use regional endpoint in almost all cases.
-    # This will be set as an annotation on the KEDA service account.
-    stsRegionalEndpoints: "true"
-    # Set to the value of the service account token expiration duration.
-    # This will be set as an annotation on the KEDA service account.
-    tokenExpiration: 86400
+  aws:
+    irsa:
+      # Set to true to enable AWS IAM Roles for Service Accounts (IRSA).
+      enabled: false
+      # Sets the token audience for IRSA.
+      # This will be set as an annotation on the KEDA service account.
+      audience: "sts.amazonaws.com"
+      # Set to the value of the ARN of an IAM role with a web identity provider.
+      # This will be set as an annotation on the KEDA service account.
+      roleArn: ""
+      # Sets the use of an STS regional endpoint instead of global. 
+      # Recommended to use regional endpoint in almost all cases.
+      # This will be set as an annotation on the KEDA service account.
+      stsRegionalEndpoints: "true"
+      # Set to the value of the service account token expiration duration.
+      # This will be set as an annotation on the KEDA service account.
+      tokenExpiration: 86400
 
 # Set this if you are using an external scaler and want to communicate
 # over TLS (recommended). This variable holds the name of the secret that


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->
Signed-off-by: Steven Jenkins De Haro 20492442+StevenJDH@users.noreply.github.com

Adds support for AWS IAM Roles for Service Accounts (IRSA) in the helm chart to the KEDA service account. For example, if `podIdentity.irsa.enabled` is set `true` along with the needed config, the below will be rendered:

```yaml
apiVersion: v1
kind: ServiceAccount
...
  annotations:
    eks.amazonaws.com/audience: "sts.amazonaws.com"
    eks.amazonaws.com/role-arn: "arn:aws:iam::000000000000:role/example-irsa-role"
    eks.amazonaws.com/sts-regional-endpoints: "true"
    eks.amazonaws.com/token-expiration: "3600"
...
```

### Checklist

- [ X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ X] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [X ] README is updated with new configuration values *(if applicable)*

Fixes #233 
