### PR TITLE
default value is array instead of object

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -110,7 +110,7 @@ their default values.
 | `resources.operator`                                       | Manage resource request & limits of KEDA operator pod ([docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)) | `` |
 | `resources.metricServer`                                   | Manage resource request & limits of KEDA metrics apiserver pod ([docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)) | `` |
 | `nodeSelector`                                             | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) | `{}` |
-| `tolerations`                                              | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) | `{}` |
+| `tolerations`                                              | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) | `[]` |
 | `topologySpreadConstraints.operator` | object | `{}` | Pod Topology Constraints of KEDA operator pod https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ |
 | `topologySpreadConstraints.metricsServer` | object | `{}` | Pod Topology Constraints of KEDA metrics apiserver pod https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ |
 | `affinity`                                                 | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) for both KEDA operator and Metrics API Server | `{}` |


### PR DESCRIPTION
The default value of the `toleration`  parameter in the documentation was incorrect.

Signed-off-by: schelv <13403863+schelv@users.noreply.github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Fixes #
