### PR TITLE
fix: bump Azure/setup-helm to v3 for not using helm in alpha version

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Helm install
-      uses: Azure/setup-helm@v1
+      uses: Azure/setup-helm@v3
 
     - name: Lint 'KEDA' Helm chart
       run: helm lint keda
@@ -60,7 +60,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Helm install
-      uses: Azure/setup-helm@v1
+      uses: Azure/setup-helm@v3
       
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@main

--- a/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
+++ b/.github/workflows/ci-external-scaler-azure-cosmos-db.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Helm install
-      uses: Azure/setup-helm@v1
+      uses: Azure/setup-helm@v3
 
     - name: Lint 'Azure Cosmos DB external scaler' Helm chart
       run: helm lint ./external-scaler-azure-cosmos-db/ --strict
@@ -60,7 +60,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Helm install
-      uses: Azure/setup-helm@v1
+      uses: Azure/setup-helm@v3
       
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@v1.2.0

--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Helm install
-      uses: Azure/setup-helm@v1
+      uses: Azure/setup-helm@v3
 
     - name: Lint 'http-add-on' Helm chart
       run: helm lint http-add-on
@@ -51,7 +51,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Helm install
-      uses: Azure/setup-helm@v1
+      uses: Azure/setup-helm@v3
 
     - name: Create k8s ${{ matrix.kubernetesVersion }} Kind Cluster
       uses: helm/kind-action@main


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@scrm.lidl>


- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

