### PR TITLE
Add workload identity labels to keda pods

### DIFF
--- a/keda/templates/01-serviceaccount.yaml
+++ b/keda/templates/01-serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.serviceAccount.name }}
     {{- if .Values.podIdentity.azureWorkload.enabled }}
-    azure.workload.identity/use: {{ .Values.podIdentity.azureWorkload.enabled | quote }}
+    azure.workload.identity/use: "true"
     {{- end }}
     {{- include "keda.labels" . | indent 4 }}
   {{- if or .Values.podIdentity.azureWorkload.enabled .Values.podIdentity.aws.irsa.enabled .Values.serviceAccount.annotations }}

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- if .Values.podLabels.keda }}
         {{- toYaml .Values.podLabels.keda | nindent 8}}
         {{- end }}
+        {{- if .Values.podIdentity.azureWorkload.enabled }}
+        azure.workload.identity/use: {{ .Values.podIdentity.azureWorkload.enabled | quote }}
+        {{- end }}
       {{- if .Values.podAnnotations.keda }}
       annotations:
       {{- toYaml .Values.podAnnotations.keda | nindent 8}}

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         {{- toYaml .Values.podLabels.keda | nindent 8}}
         {{- end }}
         {{- if .Values.podIdentity.azureWorkload.enabled }}
-        azure.workload.identity/use: {{ .Values.podIdentity.azureWorkload.enabled | quote }}
+        azure.workload.identity/use: "true"
         {{- end }}
       {{- if .Values.podAnnotations.keda }}
       annotations:

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -6,9 +6,6 @@ metadata:
   labels:
     app: {{ .Values.operator.name }}-metrics-apiserver
     app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver
-    {{- if .Values.podIdentity.azureWorkload.enabled }}
-    azure.workload.identity/use: {{ .Values.podIdentity.azureWorkload.enabled | quote }}
-    {{- end }}
     {{- include "keda.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.metricsServer.replicaCount }}
@@ -30,6 +27,9 @@ spec:
         {{- end }}
         {{- if .Values.podLabels.metricsAdapter }}
         {{- toYaml .Values.podLabels.metricsAdapter | nindent 8}}
+        {{- end }}
+        {{- if .Values.podIdentity.azureWorkload.enabled }}
+        azure.workload.identity/use: "true"
         {{- end }}
       annotations:
       {{- if and .Values.prometheus.metricServer.enabled ( not .Values.prometheus.metricServer.podMonitor.enabled ) }}

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: {{ .Values.operator.name }}-metrics-apiserver
     app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver
+    {{- if .Values.podIdentity.azureWorkload.enabled }}
+    azure.workload.identity/use: {{ .Values.podIdentity.azureWorkload.enabled | quote }}
+    {{- end }}
     {{- include "keda.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.metricsServer.replicaCount }}


### PR DESCRIPTION
Signed-off-by: Vighnesh Shenoy <vshenoy@microsoft.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

The `azure.workload.identity/use` label will now be required for pods as well (besides the service account).

https://github.com/Azure/azure-workload-identity/pull/629

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #
