### PR TITLE
fix: Use correct PDB api

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -83,10 +83,10 @@ jobs:
       run: kubectl create ns keda
 
     - name: Template Helm chart
-      run: helm template keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }} --set podIdentity.azureWorkload.tenantId=${{ matrix.tenantId }} --set podIdentity.azureWorkload.clientId=${{ matrix.clientId }}
+      run: helm template keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }} --set podIdentity.azureWorkload.tenantId=${{ matrix.tenantId }} --set podIdentity.azureWorkload.clientId=${{ matrix.clientId }} --set podDisruptionBudget.operator.maxUnavailable=1 --set podDisruptionBudget.metricServer.maxUnavailable=1
 
     - name: Install Helm chart
-      run: helm install keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }} --set podIdentity.azureWorkload.tenantId=${{ matrix.tenantId }} --set podIdentity.azureWorkload.clientId=${{ matrix.clientId }}
+      run: helm install keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }} --set podIdentity.azureWorkload.tenantId=${{ matrix.tenantId }} --set podIdentity.azureWorkload.clientId=${{ matrix.clientId }} --set podDisruptionBudget.operator.maxUnavailable=1 --set podDisruptionBudget.metricServer.maxUnavailable=1
 
     - name: Show Kubernetes resources
       run: kubectl get all --namespace keda

--- a/keda/templates/13-keda-poddisruptionbudget.yaml
+++ b/keda/templates/13-keda-poddisruptionbudget.yaml
@@ -1,9 +1,5 @@
 {{- if or (or .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable)  .Values.podDisruptionBudget.operator }}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
 kind: PodDisruptionBudget
 metadata:
   namespace: {{ .Release.Namespace }}

--- a/keda/templates/25-metrics-poddisruptionbudget.yaml
+++ b/keda/templates/25-metrics-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if or (or .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable)  .Values.podDisruptionBudget.metricServer }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge.turrado@scrm.lidl>

As minimum k8s version for the chart is 1.23, doesn't make sense to have logic to use `policy/v1beta1` or `policy/v1`. This PR updates the versions and also modify the CI to deploy PDBs during checks to fast detect issues related with them during PRs

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/charts/issues/325
