### PR TITLE
Support disable keep http connection alive

### DIFF
--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -106,6 +106,10 @@ spec:
             - name: KEDA_HTTP_DEFAULT_TIMEOUT
               value: {{ .Values.http.timeout | quote }}
             {{- end }}
+            {{- if ( not .Values.http.keepAlive.enabled ) }}
+            - name: KEDA_HTTP_DISABLE_KEEP_ALIVE
+              value: "true"
+            {{- end }}
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 -}}
             {{- end }}

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -88,6 +88,10 @@ spec:
             - name: KEDA_HTTP_DEFAULT_TIMEOUT
               value: {{ .Values.http.timeout | quote }}
             {{- end }}
+            {{- if ( not .Values.http.keepAlive.enabled ) }}
+            - name: KEDA_HTTP_DISABLE_KEEP_ALIVE
+              value: "true"
+            {{- end }}
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 -}}
             {{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -131,7 +131,7 @@ podIdentity:
       # Set to the value of the ARN of an IAM role with a web identity provider.
       # This will be set as an annotation on the KEDA service account.
       roleArn: ""
-      # Sets the use of an STS regional endpoint instead of global. 
+      # Sets the use of an STS regional endpoint instead of global.
       # Recommended to use regional endpoint in almost all cases.
       # This will be set as an annotation on the KEDA service account.
       stsRegionalEndpoints: "true"
@@ -259,6 +259,8 @@ priorityClassName: ""
 ## reasonable default
 http:
   timeout: 3000
+  keepAlive:
+    enabled: true
 
 ## Extra KEDA Operator and Metrics Adapter container arguments
 extraArgs:


### PR DESCRIPTION
Support disable keep http connection alive

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
- [x] README is updated with new configuration values *(if applicable)*

Relates to https://github.com/kedacore/keda/pull/3878
Relates to https://github.com/kedacore/keda/issues/3874
