### PR TITLE
fix(keda): Remove unknown flag when enabling prometheus on the operator

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -82,6 +82,11 @@ jobs:
     - name: Generate values
       run: |
         cat <<EOF > test-values.yaml
+        image:
+          keda:
+            tag: main
+          metricsApiServer:   
+            tag: main
         podIdentity:
           azureWorkload:
             enabled: ${{ matrix.enableAzureWorkloadIdentity }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -79,14 +79,29 @@ jobs:
       run: |
         helm version
 
+    - name: Generate values
+      run: |
+        cat <<EOF > test-values.yaml
+        podIdentity:
+          azureWorkload:
+            enabled: ${{ matrix.enableAzureWorkloadIdentity }}
+            tenantId: ${{ matrix.tenantId }}
+            clientId: ${{ matrix.clientId }}
+        podDisruptionBudget:
+          operator:
+            maxUnavailable: 1 
+          metricServer:
+            maxUnavailable: 1
+        EOF
+
     - name: Create KEDA namespace
       run: kubectl create ns keda
 
     - name: Template Helm chart
-      run: helm template keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }} --set podIdentity.azureWorkload.tenantId=${{ matrix.tenantId }} --set podIdentity.azureWorkload.clientId=${{ matrix.clientId }} --set podDisruptionBudget.operator.maxUnavailable=1 --set podDisruptionBudget.metricServer.maxUnavailable=1
+      run: helm template keda ./keda/ --namespace keda --values test-values.yaml
 
     - name: Install Helm chart
-      run: helm install keda ./keda/ --namespace keda --set podIdentity.azureWorkload.enabled=${{ matrix.enableAzureWorkloadIdentity }} --set podIdentity.azureWorkload.tenantId=${{ matrix.tenantId }} --set podIdentity.azureWorkload.clientId=${{ matrix.clientId }} --set podDisruptionBudget.operator.maxUnavailable=1 --set podDisruptionBudget.metricServer.maxUnavailable=1
+      run: helm install keda ./keda/ --namespace keda --values test-values.yaml --wait
 
     - name: Show Kubernetes resources
       run: kubectl get all --namespace keda

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -92,6 +92,11 @@ jobs:
             maxUnavailable: 1 
           metricServer:
             maxUnavailable: 1
+        prometheus:
+          operator:
+            enabled: true
+            podMonitor:
+              enabled: true
         EOF
 
     - name: Create KEDA namespace

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -99,6 +99,12 @@ jobs:
               enabled: true
         EOF
 
+    - name: Install deps
+      run: |
+        helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+        helm repo update
+        helm install prometheus-stack prometheus-community/kube-prometheus-stack --namespace monitoring --create-namespace --wait
+
     - name: Create KEDA namespace
       run: kubectl create ns keda
 

--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -73,7 +73,7 @@ spec:
           - "--zap-encoder={{ .Values.logging.operator.format }}"
           - "--zap-time-encoding={{ .Values.logging.operator.timeEncoding }}"
           {{- if .Values.prometheus.operator.enabled }}
-          - --metrics-port=:{{ .Values.prometheus.operator.port }}
+          - --metrics-bind-address=:{{ .Values.prometheus.operator.port }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs.keda }}
           - --{{ $key }}={{ $value }}


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

This PR removes the old parameter `--metrics-port` and modifies the CI check covering the monitoring as part of the check. Also replaces the tag for CI to enforce main, in order to detect this errors faster (currently we check with latest released version, which could be outdated for testing the chart because latest release doesn't contain incoming changes)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/charts/issues/342
