### PR TITLE
fix(core): Ensure pod annotations are applied correctly

### DIFF
--- a/keda/templates/12-keda-deployment.yaml
+++ b/keda/templates/12-keda-deployment.yaml
@@ -35,11 +35,13 @@ spec:
         {{- if .Values.podIdentity.azureWorkload.enabled }}
         azure.workload.identity/use: "true"
         {{- end }}
-      {{- if .Values.podAnnotations.keda }}
       annotations:
-      {{- toYaml .Values.podAnnotations.keda | nindent 8 }}
-      {{- toYaml .Values.additionalAnnotations | nindent 8 }}
-      {{- end }}
+        {{- if .Values.podAnnotations.keda }}
+        {{- toYaml .Values.podAnnotations.keda | nindent 8 }}
+        {{- end }}
+        {{- if .Values.additionalAnnotations }}
+        {{- toYaml .Values.additionalAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -34,15 +34,17 @@ spec:
         azure.workload.identity/use: "true"
         {{- end }}
       annotations:
-      {{- toYaml .Values.additionalAnnotations | nindent 8 }}
-      {{- if and .Values.prometheus.metricServer.enabled ( not .Values.prometheus.metricServer.podMonitor.enabled ) }}
+        {{- if .Values.additionalAnnotations }}
+        {{- toYaml .Values.additionalAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.prometheus.metricServer.enabled ( not .Values.prometheus.metricServer.podMonitor.enabled ) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.metricServer.port | quote }}
         prometheus.io/path: {{ .Values.prometheus.metricServer.path }}
-      {{- end }}
-      {{- if .Values.podAnnotations.metricsAdapter }}
-      {{- toYaml .Values.podAnnotations.metricsAdapter | nindent 8}}
-      {{- end }}
+        {{- end }}
+        {{- if .Values.podAnnotations.metricsAdapter }}
+        {{- toYaml .Values.podAnnotations.metricsAdapter | nindent 8}}
+        {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Made inclusion of `.Values.additionalAnnotations` conditional

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #345
