### PR TITLE
Fix additional annotation being rendered in the same line with a static annotation

### DIFF
--- a/keda/templates/02-crd-clustertriggerauthentications.yaml
+++ b/keda/templates/02-crd-clustertriggerauthentications.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
     {{- if .Values.additionalAnnotations }}
-    {{- toYaml .Values.additionalAnnotations | indent 4 }}
+    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}

--- a/keda/templates/03-crd-scaledjobs.keda.sh.yaml
+++ b/keda/templates/03-crd-scaledjobs.keda.sh.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
     {{- if .Values.additionalAnnotations }}
-    {{- toYaml .Values.additionalAnnotations | indent 4 }}
+    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}

--- a/keda/templates/04-crd-scaledobjects.keda.sh.yaml
+++ b/keda/templates/04-crd-scaledobjects.keda.sh.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
     {{- if .Values.additionalAnnotations }}
-    {{- toYaml .Values.additionalAnnotations | indent 4 }}
+    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}

--- a/keda/templates/05-crd-triggerauthentications.keda.sh.yaml
+++ b/keda/templates/05-crd-triggerauthentications.keda.sh.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
     {{- if .Values.additionalAnnotations }}
-    {{- toYaml .Values.additionalAnnotations | indent 4 }}
+    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}


### PR DESCRIPTION
When additionalAnnotations is set - the chart is rendered with the first additional annotation on the same line with a static annotation.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
