### PR TITLE
Adds support for Prometheus ServiceMonitor & adds missing Prometheus scraping annotations

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -135,6 +135,16 @@ their default values.
 | `prometheus.metricServer.podMonitor.namespace`             | Scraping namespace for metric server using podMonitor crd (prometheus operator) | ``
 | `prometheus.metricServer.podMonitor.additionalLabels`      | Additional labels to add for metric server using podMonitor crd (prometheus operator) | `{}`
 | `prometheus.metricServer.podMonitor.relabelings`           | List of expressions that define custom relabeling rules for metric server podMonitor crd (prometheus operator) | `[]`
+| `prometheus.metricServer.serviceMonitor.enabled`           | Enable monitoring for metric server using podMonitor crd (prometheus operator) | `false`
+| `prometheus.metricServer.serviceMonitor.jobLabel`         | JobLabel selects the label from the associated Kubernetes service which will be used as the job label for all metrics. [ServiceMonitor Spec](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor) | ``
+| `prometheus.metricServer.serviceMonitor.targetLabels`         | TargetLabels transfers labels from the Kubernetes `Service` onto the created metrics | `[]`
+| `prometheus.metricServer.serviceMonitor.podTargetLabels`        | PodTargetLabels transfers labels on the Kubernetes `Pod` onto the created metrics | `[]`
+| `prometheus.metricServer.serviceMonitor.port`         | Name of the service port this endpoint refers to. Mutually exclusive with targetPort | `metrics`
+| `prometheus.metricServer.serviceMonitor.targetPort`         | Name or number of the target port of the Pod behind the Service, the port must be specified with container port property. Mutually exclusive with port | ``
+| `prometheus.metricServer.serviceMonitor.interval`         | Interval at which metrics should be scraped If not specified Prometheus’ global scrape interval is used. | ``
+| `prometheus.metricServer.serviceMonitor.scrapeTimeout`        | Timeout after which the scrape is ended If not specified, the Prometheus global scrape timeout is used unless it is less than Interval in which the latter is used | ``
+| `prometheus.metricServer.serviceMonitor.relabellings`         | List of expressions that define custom relabeling rules for metric server ServiceMonitor crd (prometheus operator). [RelabelConfig Spec](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig) | `[]`
+| `prometheus.metricServer.serviceMonitor.additionalLabels`         | Additional labels to add for metric server using ServiceMonitor crd (prometheus operator) | `{}`
 | `prometheus.operator.enabled`                              | Enable KEDA Operator prometheus metrics expose | `false`
 | `prometheus.operator.port`                                 | Port used for exposing KEDA Operator prometheus metrics | `8080`
 | `prometheus.operator.podMonitor.enabled`                   | Enable monitoring for KEDA Operator using podMonitor crd (prometheus operator) | `false`
@@ -142,6 +152,16 @@ their default values.
 | `prometheus.operator.podMonitor.scrapeTimeout`             | Scraping timeout for KEDA Operator using podMonitor crd (prometheus operator) | ``
 | `prometheus.operator.podMonitor.namespace`                 | Scraping namespace for KEDA Operator using podMonitor crd (prometheus operator) | ``
 | `prometheus.operator.podMonitor.additionalLabels`          | Additional labels to add for KEDA Operator using podMonitor crd (prometheus operator) | `{}`
+| `prometheus.operator.serviceMonitor.enabled`           | Enable monitoring for metric server using podMonitor crd (prometheus operator) | `false`
+| `prometheus.operator.serviceMonitor.jobLabel`         | JobLabel selects the label from the associated Kubernetes service which will be used as the job label for all metrics. [ServiceMonitor Spec](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor) | ``
+| `prometheus.operator.serviceMonitor.targetLabels`         | TargetLabels transfers labels from the Kubernetes `Service` onto the created metrics | `[]`
+| `prometheus.operator.serviceMonitor.podTargetLabels`        | PodTargetLabels transfers labels on the Kubernetes `Pod` onto the created metrics | `[]`
+| `prometheus.operator.serviceMonitor.port`         | Name of the service port this endpoint refers to. Mutually exclusive with targetPort | `metrics`
+| `prometheus.operator.serviceMonitor.targetPort`         | Name or number of the target port of the Pod behind the Service, the port must be specified with container port property. Mutually exclusive with port | ``
+| `prometheus.operator.serviceMonitor.interval`         | Interval at which metrics should be scraped If not specified Prometheus’ global scrape interval is used. | ``
+| `prometheus.operator.serviceMonitor.scrapeTimeout`        | Timeout after which the scrape is ended If not specified, the Prometheus global scrape timeout is used unless it is less than Interval in which the latter is used | ``
+| `prometheus.operator.serviceMonitor.relabellings`         | List of expressions that define custom relabeling rules for metric server ServiceMonitor crd (prometheus operator). [RelabelConfig Spec](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig) | `[]`
+| `prometheus.metricServer.serviceMonitor.additionalLabels`         | Additional labels to add for metric server using ServiceMonitor crd (prometheus operator) | `{}`
 | `prometheus.operator.prometheusRules.enabled`              | Enable monitoring for KEDA Operator using prometheusRules crd (prometheus operator) | `false`
 | `prometheus.operator.prometheusRules.namespace`            | Scraping namespace for KEDA Operator using prometheusRules crd (prometheus operator) | ``
 | `prometheus.operator.prometheusRules.additionalLabels`     | Additional labels to add for KEDA Operator using prometheusRules crd (prometheus operator) | `{}`

--- a/keda/templates/13-keda-service.yaml
+++ b/keda/templates/13-keda-service.yaml
@@ -5,7 +5,7 @@ metadata:
     {{- if and .Values.prometheus.operator.enabled ( not (or .Values.prometheus.operator.podMonitor.enabled .Values.prometheus.operator.serviceMonitor.enabled )) }}
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.prometheus.operator.port | quote }}
-    prometheus.io/path: {{ .Values.prometheus.operator.path }}
+    prometheus.io/path: "/metrics"
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}

--- a/keda/templates/13-keda-service.yaml
+++ b/keda/templates/13-keda-service.yaml
@@ -1,6 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    {{- if and .Values.prometheus.operator.enabled ( not (or .Values.prometheus.operator.podMonitor.enabled .Values.prometheus.operator.serviceMonitor.enabled )) }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.prometheus.operator.port | quote }}
+    prometheus.io/path: {{ .Values.prometheus.operator.path }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/17-keda-servicemonitor.yaml
+++ b/keda/templates/17-keda-servicemonitor.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.prometheus.operator.enabled .Values.prometheus.operator.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.operator.name }}
+  annotations:
+    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.operator.name }}
+    {{- include "keda.labels" . | indent 4 }}
+    {{- range $key, $value := .Values.prometheus.operator.serviceMonitor.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- with .Values.prometheus.operator.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+spec:
+  {{- with .Values.prometheus.operator.serviceMonitor.jobLabel }}
+  jobLabel: {{ . }}
+  {{- end }}
+  {{- with .Values.prometheus.operator.serviceMonitor.targetLabels }}
+  targetLabels:
+  {{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.prometheus.operator.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{ toYaml . | indent 4 }}
+  {{- end }}
+  endpoints:
+  - port: {{ .Values.prometheus.operator.serviceMonitor.port }}
+    {{- with .Values.prometheus.operator.serviceMonitor.targetPort }}
+    targetPort: {{ . }}
+    {{- end }}
+    path: {{ .Values.prometheus.operator.serviceMonitor.path }}
+    {{- with .Values.prometheus.operator.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.prometheus.operator.serviceMonitor.relabellings }}
+    relabelings:
+    {{ toYaml . | indent 6 }}
+    {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.operator.name }}
+{{- end }}

--- a/keda/templates/17-keda-servicemonitor.yaml
+++ b/keda/templates/17-keda-servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- with .Values.prometheus.operator.serviceMonitor.targetPort }}
     targetPort: {{ . }}
     {{- end }}
-    path: {{ .Values.prometheus.operator.serviceMonitor.path }}
+    path: /metrics
     {{- with .Values.prometheus.operator.serviceMonitor.interval }}
     interval: {{ . }}
     {{- end }}

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         {{- if .Values.additionalAnnotations }}
         {{- toYaml .Values.additionalAnnotations | nindent 8 }}
         {{- end }}
-        {{- if and .Values.prometheus.metricServer.enabled ( not (and .Values.prometheus.metricServer.podMonitor.enabled .Values.prometheus.metricServer.serviceMonitor.enabled )) }}
+        {{- if and .Values.prometheus.metricServer.enabled ( not (or .Values.prometheus.metricServer.podMonitor.enabled .Values.prometheus.metricServer.serviceMonitor.enabled )) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.metricServer.port | quote }}
         prometheus.io/path: {{ .Values.prometheus.metricServer.path }}

--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         {{- if .Values.additionalAnnotations }}
         {{- toYaml .Values.additionalAnnotations | nindent 8 }}
         {{- end }}
-        {{- if and .Values.prometheus.metricServer.enabled ( not .Values.prometheus.metricServer.podMonitor.enabled ) }}
+        {{- if and .Values.prometheus.metricServer.enabled ( not (and .Values.prometheus.metricServer.podMonitor.enabled .Values.prometheus.metricServer.serviceMonitor.enabled )) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.metricServer.port | quote }}
         prometheus.io/path: {{ .Values.prometheus.metricServer.path }}

--- a/keda/templates/23-metrics-service.yaml
+++ b/keda/templates/23-metrics-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver
+    app: {{ .Values.operator.name }}-metrics-apiserver
     {{- include "keda.labels" . | indent 4 }}
   name: {{ .Values.operator.name }}-metrics-apiserver
   namespace: {{ .Release.Namespace }}

--- a/keda/templates/27-metrics-servicemonitor.yaml
+++ b/keda/templates/27-metrics-servicemonitor.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.prometheus.metricServer.enabled .Values.prometheus.metricServer.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Values.operator.name }}-metrics-apiserver
+  annotations:
+    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.operator.name }}
+    {{- include "keda.labels" . | indent 4 }}
+    {{- range $key, $value := .Values.prometheus.metricServer.serviceMonitor.additionalLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- with .Values.prometheus.metricServer.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+spec:
+  {{- with .Values.prometheus.metricServer.serviceMonitor.jobLabel }}
+  jobLabel: {{ . }}
+  {{- end }}
+  {{- with .Values.prometheus.metricServer.serviceMonitor.targetLabels }}
+  targetLabels:
+  {{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.prometheus.metricServer.serviceMonitor.podTargetLabels }}
+  podTargetLabels:
+  {{ toYaml . | indent 4 }}
+  {{- end }}
+  endpoints:
+  - port: {{ .Values.prometheus.metricServer.serviceMonitor.port }}
+    {{- with .Values.prometheus.metricServer.serviceMonitor.targetPort }}
+    targetPort: {{ . }}
+    {{- end }}
+    path: {{ .Values.prometheus.metricServer.serviceMonitor.path }}
+    {{- with .Values.prometheus.metricServer.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.prometheus.metricServer.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.prometheus.metricServer.serviceMonitor.relabellings }}
+    relabelings:
+    {{ toYaml . | indent 6 }}
+    {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver
+{{- end }}

--- a/keda/templates/27-metrics-servicemonitor.yaml
+++ b/keda/templates/27-metrics-servicemonitor.yaml
@@ -27,11 +27,11 @@ spec:
   {{ toYaml . | indent 4 }}
   {{- end }}
   endpoints:
-  - port: {{ .Values.prometheus.metricServer.serviceMonitor.port }}
+  - port: {{ .Values.prometheus.metricServer.portName }}
     {{- with .Values.prometheus.metricServer.serviceMonitor.targetPort }}
     targetPort: {{ . }}
     {{- end }}
-    path: {{ .Values.prometheus.metricServer.serviceMonitor.path }}
+    path: {{ .Values.prometheus.metricServer.path }}
     {{- with .Values.prometheus.metricServer.serviceMonitor.interval }}
     interval: {{ . }}
     {{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -312,6 +312,7 @@ prometheus:
   operator:
     enabled: false
     port: 8080
+    path: /metrics
     serviceMonitor:
       # Enables ServiceMonitor creation for the Prometheus Operator
       enabled: false

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -296,7 +296,6 @@ prometheus:
       podTargetLabels: []
       port: metrics
       targetPort:
-      path: /metrics
       interval:
       scrapeTimeout:
       relabellings: []
@@ -312,7 +311,6 @@ prometheus:
   operator:
     enabled: false
     port: 8080
-    path: /metrics
     serviceMonitor:
       # Enables ServiceMonitor creation for the Prometheus Operator
       enabled: false
@@ -321,7 +319,6 @@ prometheus:
       podTargetLabels: []
       port: metrics
       targetPort:
-      path: /metrics
       interval:
       scrapeTimeout:
       relabellings: []

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -288,6 +288,19 @@ prometheus:
     port: 9022
     portName: metrics
     path: /metrics
+    serviceMonitor:
+      # Enables ServiceMonitor creation for the Prometheus Operator
+      enabled: false
+      jobLabel:
+      targetLabels: []
+      podTargetLabels: []
+      port: metrics
+      targetPort:
+      path: /metrics
+      interval:
+      scrapeTimeout:
+      relabellings: []
+      additionalLabels: {}
     podMonitor:
       # Enables PodMonitor creation for the Prometheus Operator
       enabled: false
@@ -299,6 +312,19 @@ prometheus:
   operator:
     enabled: false
     port: 8080
+    serviceMonitor:
+      # Enables ServiceMonitor creation for the Prometheus Operator
+      enabled: false
+      jobLabel:
+      targetLabels: []
+      podTargetLabels: []
+      port: metrics
+      targetPort:
+      path: /metrics
+      interval:
+      scrapeTimeout:
+      relabellings: []
+      additionalLabels: {}
     podMonitor:
       # Enables PodMonitor creation for the Prometheus Operator
       enabled: false


### PR DESCRIPTION
This PR adds support for Prometheus ServiceMonitor as part of #339 and fixes the missing Prometheus scraping annotations of #354 . 

While the `metricServer` configuration is deprecated, I assume that it might be in use in some places and easier to set before migrating for some folks, so I have added the same support to it until it will be completely removed. 

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] README is updated with new configuration values *(if applicable)*

Fixes #339
Fixes #354 
