### PR TITLE
chore(http-add-on): Use 3 replicas as minimum for interceptor

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -118,7 +118,7 @@ their default values.
 | `interceptor.admin.port` | The port for the interceptor's admin server to run on | `9090` |
 | `interceptor.proxy.service` | The name of the Kubernetes `Service` for the interceptor's proxy service. This is the service that accepts live HTTP traffic. | `interceptor-proxy` |
 | `interceptor.proxy.port` | The port on which the interceptor's proxy service will listen for live HTTP traffic | `8080` |
-| `interceptor.replicas.min` | The minimum number of interceptor replicas that should ever be running | `1` |
+| `interceptor.replicas.min` | The minimum number of interceptor replicas that should ever be running | `3` |
 | `interceptor.replicas.max` | The maximum number of interceptor replicas that should ever be running | `50` |
 | `interceptor.replicas.waitTimeout` | The maximum time the interceptor should wait for an HTTP request to reach a backend before it is considered a failure | `1500ms` |
 | `interceptor.scaledObject.pollingInterval` | The interval (in milliseconds) that KEDA should poll the external scaler to fetch scaling metrics about the interceptor | `1` |

--- a/http-add-on/templates/deployment-interceptor.yaml
+++ b/http-add-on/templates/deployment-interceptor.yaml
@@ -17,7 +17,7 @@ metadata:
   name: {{ .Chart.Name }}-interceptor
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.interceptor.replicas.min }}
   selector:
     matchLabels:
       control-plane: interceptor

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -66,7 +66,7 @@ interceptor:
   replicas:
     # the minimum number of interceptors that should be
     # running at any given time
-    min: 1
+    min: 3
     # the maximum number of interceptors that should be 
     # running at any given time
     max: 50


### PR DESCRIPTION
Use 3 replicas as minimum for interceptor to reduce blast radius in case one goes down.

More resilience tweaks will follow.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
