### PR TITLE
fix: Remove duplicate key in http-addon rbac

### DIFF
--- a/http-add-on/templates/rbac.yml
+++ b/http-add-on/templates/rbac.yml
@@ -31,7 +31,6 @@ metadata:
     {{- include "keda-addons-http.labels" . | indent 4 }}
   name: {{ .Chart.Name }}-role
 rules:
-rules:
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Noticed this while trying to use the kustomize helm chart inflator

Signed-off-by: Aaron Batilo <AaronBatilo@gmail.com>