### PR TITLE
fix: Core Helm chart metadata is outdated

### DIFF
--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -8,11 +8,11 @@ kubeVersion: ">=v1.23.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.9.3
+version: 2.9.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.9.2
+appVersion: 2.9.3
 
 home: https://github.com/kedacore/keda
 icon: https://raw.githubusercontent.com/kedacore/keda/main/images/keda-logo-500x500-white.png


### PR DESCRIPTION
Core Helm chart metadata is outdated.

Follow-up for #386

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
