### PR TITLE
chore: add minutes and seconds to cert-manager certificates

### DIFF
--- a/keda/templates/41-cert-manager-self-ca.yaml
+++ b/keda/templates/41-cert-manager-self-ca.yaml
@@ -11,8 +11,8 @@ spec:
   privateKey:
     algorithm: RSA
     size: 2048
-  duration: 8760h # 1 year
-  renewBefore: 5840h # 8 months
+  duration: 8760h0m0s # 1 year
+  renewBefore: 5840h0m0s # 8 months
   issuerRef:
     name: {{ .Values.operator.name }}-selfsigned-issuer
     kind: Issuer

--- a/keda/templates/43-cert-manager-keda-tls-certificate.yaml
+++ b/keda/templates/43-cert-manager-keda-tls-certificate.yaml
@@ -26,8 +26,8 @@ spec:
   privateKey:
     algorithm: RSA
     size: 2048
-  duration: 8760h # 1 year
-  renewBefore: 5840h # 8 months
+  duration: 8760h0m0s # 1 year
+  renewBefore: 5840h0m0s # 8 months
   issuerRef:
     name: {{ .Values.operator.name }}-issuer
     kind: Issuer


### PR DESCRIPTION
In some scenarios using gitops (like using ArgoCD), the current certificate spec isn't enough because minutes and seconds are missing. As the desired manifest (without min a sec) doesn't match with the live manifest (fulfilled with min and sec), ArgoCD shows an OutOfSync warning. This is skippable by config, but if the chart uses the full values, ignoring isn't needed
![image](https://user-images.githubusercontent.com/36899226/224170000-b0182540-dff2-4766-acf4-34c0c9386d67.png)


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

