### PR TITLE
Fix extraVolumes and extraVolumeMounts indentation

### DIFF
--- a/keda/templates/22-metrics-deployment.yaml
+++ b/keda/templates/22-metrics-deployment.yaml
@@ -148,7 +148,7 @@ spec:
             mountPath: /hashicorp-vaultcerts
           {{- end }}
           {{- if .Values.volumes.metricsApiServer.extraVolumeMounts }}
-          {{- toYaml .Values.volumes.metricsApiServer.extraVolumeMounts | nindent 12 }}
+          {{- toYaml .Values.volumes.metricsApiServer.extraVolumeMounts | nindent 10 }}
           {{- end }}
           resources:
             {{- if .Values.resources.metricServer }}
@@ -172,7 +172,7 @@ spec:
           secretName: {{ .Values.hashiCorpVaultTLS }}
       {{- end }}
       {{- if .Values.volumes.metricsApiServer.extraVolumes }}
-      {{- toYaml .Values.volumes.metricsApiServer.extraVolumes | nindent 8 }}
+      {{- toYaml .Values.volumes.metricsApiServer.extraVolumes | nindent 6 }}
       {{- end }}
       dnsPolicy: {{ .Values.metricsServer.dnsPolicy }}
       hostNetwork: {{ .Values.metricsServer.useHostNetwork }}


### PR DESCRIPTION
Fix extraVolumes and extraVolumeMounts indentation in 22-metrics-deployment.yaml

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #410
