### PR TITLE
chore: enable `readOnlyRootFilesystem: true` for metrics server

### DIFF
--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -226,8 +226,7 @@ securityContext:
       drop:
       - ALL
     allowPrivilegeEscalation: false
-    ## Metrics server needs to write the self-signed cert. See FAQ for discussion of options.
-    # readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: true
     seccompProfile:
       type: RuntimeDefault
   webhooks:


### PR DESCRIPTION
Thanks to the cert-management, KEDA mestrics server always receives the certificates as a mounted path, so we can set `readOnlyRootFilesystem: true` as default

### Checklist

- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Related to https://github.com/kedacore/charts/issues/410
