### PR TITLE
fix: adj indent of extraVolumes & VolumeMounts in 14-keda-deployment

### DIFF
--- a/keda/templates/14-keda-deployment.yaml
+++ b/keda/templates/14-keda-deployment.yaml
@@ -142,7 +142,7 @@ spec:
             mountPath: /hashicorp-vaultcerts
           {{- end }}
           {{- if .Values.volumes.keda.extraVolumeMounts }}
-          {{- toYaml .Values.volumes.keda.extraVolumeMounts | nindent 12 }}
+          {{- toYaml .Values.volumes.keda.extraVolumeMounts | nindent 10 }}
           {{- end }}
           resources:
             {{- if .Values.resources.operator }}
@@ -167,7 +167,7 @@ spec:
           secretName: {{ .Values.hashiCorpVaultTLS }}
       {{- end }}
       {{- if .Values.volumes.keda.extraVolumes }}
-      {{- toYaml .Values.volumes.keda.extraVolumes | nindent 8 }}
+      {{- toYaml .Values.volumes.keda.extraVolumes | nindent 6 }}
       {{- end }}
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
Fix extraVolumes and extraVolumeMounts indentation in 14-keda-deployment.yaml

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #415