### PR TITLE
ci: http add on workflow now installs appropriate kedacore/keda chart for 1.23 clusters

### DIFF
--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -76,6 +76,13 @@ jobs:
       run: kubectl create ns keda
 
     - name: Install KEDA chart
+      if: matrix.kubernetesVersion == 'v1.23'
+      run: |
+        helm repo add kedacore https://kedacore.github.io/charts
+        helm install keda kedacore/keda --namespace keda --version ~2.8.4
+
+    - name: Install KEDA chart
+      if: matrix.kubernetesVersion != 'v1.23'
       run: helm install keda ./keda/ --namespace keda
 
     - name: Template Helm chart


### PR DESCRIPTION

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

For 1.23 clusters, the workflow now installs the 2.8.x chart, which is the latest chart compatible with 1.23.  All other cluster versions install the chart from the checked out code.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #422 
