### PR TITLE
Add resource template to kube-rbac-proxy container in http-add-on helm chart

### DIFF
--- a/http-add-on/templates/deployment-operator.yaml
+++ b/http-add-on/templates/deployment-operator.yaml
@@ -39,6 +39,8 @@ spec:
         - --logtostderr=true
         - --v=10
         image: "{{ .Values.images.kubeRbacProxy.name }}:{{ .Values.images.kubeRbacProxy.tag }}"
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
         name: kube-rbac-proxy
       - args:
         - --metrics-addr=127.0.0.1:8080

--- a/http-add-on/templates/deployment-operator.yaml
+++ b/http-add-on/templates/deployment-operator.yaml
@@ -40,7 +40,12 @@ spec:
         - --v=10
         image: "{{ .Values.images.kubeRbacProxy.name }}:{{ .Values.images.kubeRbacProxy.tag }}"
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+            limits:
+              cpu: 300m
+              memory: 200Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
         name: kube-rbac-proxy
       - args:
         - --metrics-addr=127.0.0.1:8080


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

The kube-rbac-proxy container in the operator deployment is missing the `resources` template. In environments where limits are required to be set on all deployments, this causes manual labor for k8s developers. 

I would update the README to reflect this change, however, the README is already essentially wrong. 
for example [The http-add-on README](https://github.com/kedacore/charts/blob/main/http-add-on/README.md#L138)
states that there is a configuration for `interceptor.resources.limits.cpu`, while in the deployment template it uses a top level resource declaration `{{- toYaml .Values.resources | nindent 12 }}`. I could instead close this MR and create another one to instead fix the templates to reflect the README.
### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

