### PR TITLE
Remove deprecated prometheus metrics from MS

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -144,8 +144,6 @@ their default values.
 | `http.timeout` | The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them) | `` |
 | `http.minTlsVersion` | The minimum TLS version to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and this value does not necessarily apply to them) | `` |
 | `service.annotations`                                      | Annotations to add the KEDA Metric Server service | `{}` |
-| `service.portHttp`                                         | Service HTTP port for KEDA Metric Server service | `80` |
-| `service.portHttpTarget`                                   | Service HTTP port for KEDA Metric Server container | `8080` |
 | `service.portHttps`                                        | HTTPS port for KEDA Metric Server service | `443` |
 | `service.portHttpsTarget`                                  | HTTPS port for KEDA Metric Server container | `6443` |
 | `prometheus.metricServer.enabled`                          | Enable metric server Prometheus metrics expose | `false` |

--- a/keda/README.md
+++ b/keda/README.md
@@ -149,9 +149,8 @@ their default values.
 | `service.portHttps`                                        | HTTPS port for KEDA Metric Server service | `443` |
 | `service.portHttpsTarget`                                  | HTTPS port for KEDA Metric Server container | `6443` |
 | `prometheus.metricServer.enabled`                          | Enable metric server Prometheus metrics expose | `false` |
-| `prometheus.metricServer.port`                             | HTTP port used for exposing metrics server prometheus metrics | `9022` |
+| `prometheus.metricServer.port`                             | HTTP port used for exposing metrics server prometheus metrics | `8088` |
 | `prometheus.metricServer.portName`                         | HTTP port name for exposing metrics server prometheus metrics | `metrics` |
-| `prometheus.metricServer.path`                             | Path used for exposing metric server prometheus metrics | `/metrics` |
 | `prometheus.metricServer.podMonitor.enabled`               | Enable monitoring for metric server using podMonitor crd (prometheus operator) | `false` |
 | `prometheus.metricServer.podMonitor.interval`              | Scraping interval for metric server using podMonitor crd (prometheus operator) | `` |
 | `prometheus.metricServer.podMonitor.scrapeTimeout`         | Scraping timeout for metric server using podMonitor crd (prometheus operator) | `` |

--- a/keda/templates/manager/service.yaml
+++ b/keda/templates/manager/service.yaml
@@ -7,6 +7,10 @@ metadata:
     prometheus.io/port: {{ .Values.prometheus.operator.port | quote }}
     prometheus.io/path: "/metrics"
     {{- end }}
+    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -107,18 +107,14 @@ spec:
             {{- end }}
           args:
           - /usr/local/bin/keda-adapter
-          - --port={{ .Values.service.portHttpTarget }}
+          - --port={{ .Values.prometheus.metricServer.port }}
           - --secure-port={{ .Values.service.portHttpsTarget }}
           - --logtostderr=true
           - --metrics-service-address={{ .Values.operator.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:9666
           - --client-ca-file={{ .Values.certificates.mountPath }}/ca.crt
           - --tls-cert-file={{ .Values.certificates.mountPath }}/tls.crt
           - --tls-private-key-file={{ .Values.certificates.mountPath }}/tls.key
-          - --cert-dir={{ .Values.certificates.mountPath }}
-          {{- if .Values.prometheus.metricServer.enabled }}
-          - --metrics-port={{ .Values.prometheus.metricServer.port }}
-          - --metrics-path={{ .Values.prometheus.metricServer.path }}
-          {{- end }}
+          - --cert-dir={{ .Values.certificates.mountPath }}          
           - --v={{ .Values.logging.metricServer.level }}
           {{- range $key, $value := .Values.extraArgs.metricsAdapter }}
           - --{{ $key }}={{ $value }}
@@ -127,14 +123,9 @@ spec:
             - containerPort: {{ .Values.service.portHttpsTarget }}
               name: https
               protocol: TCP
-            - containerPort: {{ .Values.service.portHttpTarget }}
-              name: http
-              protocol: TCP
-            {{- if .Values.prometheus.metricServer.enabled }}
             - containerPort: {{ .Values.prometheus.metricServer.port }}
-              name: metrics
+              name: {{ .Values.prometheus.metricServer.portName }}
               protocol: TCP
-            {{- end }}
           volumeMounts:
           - mountPath: {{ .Values.certificates.mountPath }}
             name: certificates

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -114,7 +114,7 @@ spec:
           - --client-ca-file={{ .Values.certificates.mountPath }}/ca.crt
           - --tls-cert-file={{ .Values.certificates.mountPath }}/tls.crt
           - --tls-private-key-file={{ .Values.certificates.mountPath }}/tls.key
-          - --cert-dir={{ .Values.certificates.mountPath }}          
+          - --cert-dir={{ .Values.certificates.mountPath }}
           - --v={{ .Values.logging.metricServer.level }}
           {{- range $key, $value := .Values.extraArgs.metricsAdapter }}
           - --{{ $key }}={{ $value }}

--- a/keda/templates/metrics-server/podmonitor.yaml
+++ b/keda/templates/metrics-server/podmonitor.yaml
@@ -18,7 +18,6 @@ spec:
   podMetricsEndpoints:
   - port: {{ .Values.prometheus.metricServer.portName }}
     path: /metrics
-    honorLabels: true
     {{- with .Values.prometheus.metricServer.podMonitor.interval }}
     interval: {{ . }}
     {{- end }}

--- a/keda/templates/metrics-server/podmonitor.yaml
+++ b/keda/templates/metrics-server/podmonitor.yaml
@@ -16,8 +16,9 @@ metadata:
   {{- end }}
 spec:
   podMetricsEndpoints:
-  - port: metrics
-    path: {{ .Values.prometheus.metricServer.path }}
+  - port: {{ .Values.prometheus.metricServer.portName }}
+    path: /metrics
+    honorLabels: true
     {{- with .Values.prometheus.metricServer.podMonitor.interval }}
     interval: {{ . }}
     {{- end }}

--- a/keda/templates/metrics-server/service.yaml
+++ b/keda/templates/metrics-server/service.yaml
@@ -8,25 +8,24 @@ metadata:
   name: {{ .Values.operator.name }}-metrics-apiserver
   namespace: {{ .Release.Namespace }}
   annotations:
-  {{- toYaml .Values.additionalAnnotations | nindent 4 }}
-  {{- range $key, $value := .Values.service.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- if and .Values.prometheus.metricServer.enabled ( not (or .Values.prometheus.metricServer.podMonitor.enabled .Values.prometheus.metricServer.serviceMonitor.enabled )) }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.prometheus.metricServer.port | quote }}
+    prometheus.io/path: "/metrics"
+    {{- end }}
+    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- range $key, $value := .Values.service.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   ports:
   - name: https
     port: {{ .Values.service.portHttps }}
     targetPort: {{ .Values.service.portHttpsTarget }}
     protocol: TCP
-  - name: http
-    port: {{ .Values.service.portHttp }}
-    targetPort: {{ .Values.service.portHttpTarget }}
-    protocol: TCP
-  {{- if .Values.prometheus.metricServer.enabled }}
   - name: {{ .Values.prometheus.metricServer.portName }}
     port: {{ .Values.prometheus.metricServer.port }}
     targetPort: {{ .Values.prometheus.metricServer.port }}
     protocol: TCP
-  {{- end }}
   selector:
     app: {{ .Values.operator.name }}-metrics-apiserver

--- a/keda/templates/metrics-server/servicemonitor.yaml
+++ b/keda/templates/metrics-server/servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- with .Values.prometheus.metricServer.serviceMonitor.targetPort }}
     targetPort: {{ . }}
     {{- end }}
-    path: {{ .Values.prometheus.metricServer.path }}
+    path: /metrics
     {{- with .Values.prometheus.metricServer.serviceMonitor.interval }}
     interval: {{ . }}
     {{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -269,8 +269,6 @@ podSecurityContext:
 
 service:
   type: ClusterIP
-  portHttp: 80
-  portHttpTarget: 8080
   portHttps: 443
   portHttpsTarget: 6443
 

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -365,9 +365,8 @@ volumes:
 prometheus:
   metricServer:
     enabled: false
-    port: 9022
+    port: 8080
     portName: metrics
-    path: /metrics
     serviceMonitor:
       # Enables ServiceMonitor creation for the Prometheus Operator
       enabled: false


### PR DESCRIPTION
### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Related to https://github.com/kedacore/keda/issues/3930
