### PR TITLE
added condition for gcp-workload-identity-setup

### DIFF
--- a/keda/templates/01-serviceaccount.yaml
+++ b/keda/templates/01-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     azure.workload.identity/use: "true"
     {{- end }}
     {{- include "keda.labels" . | indent 4 }}
-  {{- if or .Values.podIdentity.azureWorkload.enabled .Values.podIdentity.aws.irsa.enabled .Values.serviceAccount.annotations }}
+  {{- if or .Values.podIdentity.azureWorkload.enabled .Values.podIdentity.aws.irsa.enabled .Values.serviceAccount.annotations .Values.podIdentity.gcp.enabled }}
   annotations:
     {{- if .Values.additionalAnnotations }}
     {{- toYaml .Values.additionalAnnotations | indent 4 }}
@@ -33,6 +33,11 @@ metadata:
     eks.amazonaws.com/sts-regional-endpoints: {{ .Values.podIdentity.aws.irsa.stsRegionalEndpoints | quote }}
     {{- end }}
     eks.amazonaws.com/token-expiration: {{ .Values.podIdentity.aws.irsa.tokenExpiration | quote }}
+    {{- end }}
+    {{- if .Values.podIdentity.gcp.enabled }}
+    {{- if .Values.podIdentity.gcp.gcpIAMServiceAccount }}
+    iam.gke.io/gcp-service-account: {{ .Values.podIdentity.gcp.gcpIAMServiceAccount }}
+    {{- end }}
     {{- end }}
     {{- if .Values.serviceAccount.annotations }}
     {{- toYaml .Values.serviceAccount.annotations | nindent 4}}

--- a/keda/templates/14-keda-deployment.yaml
+++ b/keda/templates/14-keda-deployment.yaml
@@ -174,6 +174,9 @@ spec:
       {{- with .Values.nodeSelector }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.podIdentity.gcp.enabled }}
+        iam.gke.io/gke-metadata-server-enabled: "true"
+      {{- end }}
       {{- if .Values.operator.affinity }}
       affinity:
         {{- toYaml .Values.operator.affinity | nindent 8 }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -172,7 +172,14 @@ podIdentity:
       # Set to the value of the service account token expiration duration.
       # This will be set as an annotation on the KEDA service account.
       tokenExpiration: 86400
-
+  gcp:
+    # Set to true to enable GCP Workload Identity.
+    # See https://keda.sh/docs/2.10/authentication-providers/gcp-workload-identity/ 
+    # This will be set as a annotation on the KEDA service account.
+    enabled: false
+    # GCP IAM Service Account Email which you would like to use for workload identity.
+    gcpIAMServiceAccount: ""      
+  
 # Set this if you are using an external scaler and want to communicate
 # over TLS (recommended). This variable holds the name of the secret that
 # will be mounted to the /grpccerts path on the Pod


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Added Helm condition to add service account annotation and nodeselector to keda-operator deployment when the end user decides to use GCP Workload Identity
### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] README is updated with new configuration values *(if applicable)*
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*