### PR TITLE
Add honorLabels to keda operator and metricsserver ServiceMonitor

### DIFF
--- a/keda/templates/17-keda-servicemonitor.yaml
+++ b/keda/templates/17-keda-servicemonitor.yaml
@@ -31,6 +31,7 @@ spec:
     {{- with .Values.prometheus.operator.serviceMonitor.targetPort }}
     targetPort: {{ . }}
     {{- end }}
+    honorLabels: true
     path: /metrics
     {{- with .Values.prometheus.operator.serviceMonitor.interval }}
     interval: {{ . }}

--- a/keda/templates/27-metrics-servicemonitor.yaml
+++ b/keda/templates/27-metrics-servicemonitor.yaml
@@ -32,6 +32,7 @@ spec:
     targetPort: {{ . }}
     {{- end }}
     path: {{ .Values.prometheus.metricServer.path }}
+    honorLabels: true
     {{- with .Values.prometheus.metricServer.serviceMonitor.interval }}
     interval: {{ . }}
     {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Add `honorLabels: true` to `ServiceMonitor` of both keda metrics server and keda operator to preserve original namespace labels

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #434 
