### PR TITLE
optionaly install apiservice

### DIFF
--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -8,7 +8,7 @@ kubeVersion: ">=v1.24.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.10.2
+version: 2.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/keda/Chart.yaml
+++ b/keda/Chart.yaml
@@ -8,7 +8,7 @@ kubeVersion: ">=v1.24.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.10.3
+version: 2.10.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/keda/templates/metrics-server/apiservice.yaml
+++ b/keda/templates/metrics-server/apiservice.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.metricsServer.installApiService  }}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
@@ -24,3 +25,4 @@ spec:
   version: v1beta1
   groupPriorityMinimum: 100
   versionPriority: 100
+{{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -58,6 +58,7 @@ metricsServer:
     #         values:
     #         - keda-operator-metrics-apiserver
     #     topologyKey: "kubernetes.io/hostname"
+    installApiService: true
 
 webhooks:
   enabled: true # This value will be removed in keda v2.12
@@ -174,12 +175,12 @@ podIdentity:
       tokenExpiration: 86400
   gcp:
     # Set to true to enable GCP Workload Identity.
-    # See https://keda.sh/docs/2.10/authentication-providers/gcp-workload-identity/ 
+    # See https://keda.sh/docs/2.10/authentication-providers/gcp-workload-identity/
     # This will be set as a annotation on the KEDA service account.
     enabled: false
     # GCP IAM Service Account Email which you would like to use for workload identity.
-    gcpIAMServiceAccount: ""      
-  
+    gcpIAMServiceAccount: ""
+
 # Set this if you are using an external scaler and want to communicate
 # over TLS (recommended). This variable holds the name of the secret that
 # will be mounted to the /grpccerts path on the Pod


### PR DESCRIPTION
Adding ability to optionally install APIService/v1beta1.external.metrics.k8s.io in case of more then one release of KEDA in the cluster

Even if two keda operators are defined with `operator-name` and `watch-namespace` values there is one more shared resource 
```
SharedResourceWarning
APIService/v1beta1.external.metrics.k8s.io is part of applications APP1 and APP2
```
there is permanent concurention  for this resource between two ArgoCD applications in one cluster