### PR TITLE
remove honor label from manager service monitor

### DIFF
--- a/keda/templates/manager/podmonitor.yaml
+++ b/keda/templates/manager/podmonitor.yaml
@@ -18,7 +18,6 @@ spec:
   podMetricsEndpoints:
   - port: http
     path: /metrics
-    honorLabels: true
     {{- with .Values.prometheus.operator.podMonitor.interval }}
     interval: {{ . }}
     {{- end }}

--- a/keda/templates/manager/servicemonitor.yaml
+++ b/keda/templates/manager/servicemonitor.yaml
@@ -31,7 +31,6 @@ spec:
     {{- with .Values.prometheus.operator.serviceMonitor.targetPort }}
     targetPort: {{ . }}
     {{- end }}
-    honorLabels: true
     path: /metrics
     {{- with .Values.prometheus.operator.serviceMonitor.interval }}
     interval: {{ . }}

--- a/keda/templates/metrics-server/podmonitor.yaml
+++ b/keda/templates/metrics-server/podmonitor.yaml
@@ -18,7 +18,6 @@ spec:
   podMetricsEndpoints:
   - port: metrics
     path: {{ .Values.prometheus.metricServer.path }}
-    honorLabels: true
     {{- with .Values.prometheus.metricServer.podMonitor.interval }}
     interval: {{ . }}
     {{- end }}

--- a/keda/templates/metrics-server/servicemonitor.yaml
+++ b/keda/templates/metrics-server/servicemonitor.yaml
@@ -32,7 +32,6 @@ spec:
     targetPort: {{ . }}
     {{- end }}
     path: {{ .Values.prometheus.metricServer.path }}
-    honorLabels: true
     {{- with .Values.prometheus.metricServer.serviceMonitor.interval }}
     interval: {{ . }}
     {{- end }}


### PR DESCRIPTION
Remove a `honorLabels` field from the manager's service monitor due to changes in the keda-dashboard.json
Related PR: https://github.com/kedacore/keda/pull/4539

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

