### PR TITLE
Add aggregateToDefaultRules to http add-on

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -139,6 +139,7 @@ their default values.
 | `interceptor.resources.limits.memory`                         | The memory resource limit for the operator component | `64Mi` |
 | `interceptor.resources.requests.cpu`                          | The CPU resource request for the operator component | `250m` |
 | `interceptor.resources.requests.memory`                       | The memory resource request for the operator component | `20Mi` |
+| `rbac.aggregateToDefaultRoles`                                | Install aggregate roles for edit and view | `false`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`. For example:

--- a/http-add-on/templates/rbac-aggregateclusterroles.yaml
+++ b/http-add-on/templates/rbac-aggregateclusterroles.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.rbac.aggregateToDefaultRoles }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Chart.Name }}-edit
+  labels:
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
+    keda.sh/addon: {{ .Chart.Name }}
+    app: {{ .Chart.Name }}
+    name: {{ .Chart.Name }}-edit
+    app.kubernetes.io/name: {{ .Chart.Name }}-edit
+    {{- include "keda-addons-http.labels" . | indent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - http.keda.sh
+  resources:
+  - httpscaledobjects
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Chart.Name }}-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
+    keda.sh/addon: {{ .Chart.Name }}
+    app: {{ .Chart.Name }}
+    name: {{ .Chart.Name }}-view
+    app.kubernetes.io/name: {{ .Chart.Name }}-view
+    {{- include "keda-addons-http.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - http.keda.sh
+  resources:
+  - httpscaledobjects
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -153,4 +153,5 @@ images:
     tag: v0.13.0
 
 rbac:
+  # install aggregate roles for edit and view
   aggregateToDefaultRoles: false

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -151,3 +151,6 @@ images:
   kubeRbacProxy:
     name: gcr.io/kubebuilder/kube-rbac-proxy
     tag: v0.13.0
+
+rbac:
+  aggregateToDefaultRoles: false


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

This change is similar to https://github.com/kedacore/charts/pull/257.  It adds the AggregateToDefaultRoles to the http addon.  These ClusterRoles are optional and disabled by default. Set rbac.aggregateToDefaultRoles to enable.

Signed-off-by: Chris Reiche creiche@gmail.com

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
