### PR TITLE
fix(http-add-on): Fix resources variables for the http-add-on deploym…

### DIFF
--- a/http-add-on/templates/deployment-interceptor.yaml
+++ b/http-add-on/templates/deployment-interceptor.yaml
@@ -82,7 +82,7 @@ spec:
         - containerPort: {{ .Values.interceptor.proxy.port }}
           name: inter-proxy
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml .Values.interceptor.resources | nindent 10 }}
       terminationGracePeriodSeconds: 10
       {{- with .Values.interceptor.nodeSelector }}
       nodeSelector:

--- a/http-add-on/templates/deployment-operator.yaml
+++ b/http-add-on/templates/deployment-operator.yaml
@@ -73,7 +73,7 @@ spec:
         - containerPort: {{ .Values.operator.adminPort }}
           name: admin-http
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml .Values.operator.resources | nindent 10 }}
       terminationGracePeriodSeconds: 10
       {{- with .Values.operator.nodeSelector }}
       nodeSelector:

--- a/http-add-on/templates/deployment-scaler.yaml
+++ b/http-add-on/templates/deployment-scaler.yaml
@@ -68,7 +68,7 @@ spec:
         - name: KEDA_HTTP_SCALER_TARGET_PENDING_REQUESTS_INTERCEPTOR
           value: "{{ default 200 .Values.scaler.pendingRequestsInterceptor }}"
         resources:
-          {{- toYaml .Values.resources | nindent 12 }}
+          {{- toYaml .Values.scaler.resources | nindent 10 }}
       terminationGracePeriodSeconds: 10
       {{- with .Values.scaler.nodeSelector }}
       nodeSelector:

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -41,6 +41,13 @@ scaler:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  resources:
+    limits:
+      cpu: 0.5
+      memory: 64Mi
+    requests:
+      cpu: 250m
+      memory: 20Mi
 
 interceptor:
   # the image pull secrets for the interceptor
@@ -155,3 +162,4 @@ images:
 rbac:
   # install aggregate roles for edit and view
   aggregateToDefaultRoles: false
+


### PR DESCRIPTION
Fixes the deployment templates to actually use the `resources` values defined in the `values.yaml` file. Currently they are ignored and no resources requests or limits are set for the `http-add-on`.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
