### PR TITLE
fix: set prometheus discovery annotations on operator and webhooks

### DIFF
--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -42,6 +42,11 @@ spec:
         {{- if .Values.additionalAnnotations }}
         {{- toYaml .Values.additionalAnnotations | nindent 8 }}
         {{- end }}
+        {{- if and .Values.prometheus.operator.enabled ( not (or .Values.prometheus.operator.podMonitor.enabled .Values.prometheus.operator.serviceMonitor.enabled )) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.prometheus.operator.port | quote }}
+        prometheus.io/path: {{ .Values.prometheus.operator.path }}
+        {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         {{- if .Values.additionalAnnotations }}
         {{- toYaml .Values.additionalAnnotations | nindent 8 }}
         {{- end }}
-        {{- if and .Values.prometheus.webhooks.enabled ( not (or .Values.prometheus.webhooks.podMonitor.enabled .Values.prometheus.webhooks.serviceMonitor.enabled )) }}
+        {{- if and .Values.prometheus.webhooks.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.webhooks.port | quote }}
         prometheus.io/path: {{ .Values.prometheus.webhooks.path }}

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -37,6 +37,11 @@ spec:
         {{- if .Values.additionalAnnotations }}
         {{- toYaml .Values.additionalAnnotations | nindent 8 }}
         {{- end }}
+        {{- if and .Values.prometheus.webhooks.enabled ( not (or .Values.prometheus.webhooks.podMonitor.enabled .Values.prometheus.webhooks.serviceMonitor.enabled )) }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.prometheus.webhooks.port | quote }}
+        prometheus.io/path: {{ .Values.prometheus.webhooks.path }}
+        {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Add prometheus discovery annotations on operator and webhooks to match metricServer

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)*
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*