### PR TITLE
chore: Improve deprecation for service monitor relabelings

### DIFF
--- a/keda/Notes.txt
+++ b/keda/Notes.txt
@@ -17,5 +17,15 @@ Get details about a deployed ScaledObject:
 Get an overview of the Horizontal Pod Autoscalers (HPA) that KEDA is using behind the scenes:
   kubectl get hpa [--all-namespaces] [--namespace <namespace>]
 
+{{- if .Values.prometheus.operator.serviceMonitor.relabellings}}
+WARNING - prometheus.metricServer.operator.relabellings is deprecated, please migrate to prometheus.operator.serviceMonitor.relabelings instead.
+{{- else }}
+{{- if .Values.prometheus.metricServer.serviceMonitor.relabellings}}
+WARNING - prometheus.metricServer.serviceMonitor.relabellings is deprecated, please migrate to prometheus.metricServer.serviceMonitor.relabelings instead.
+{{- else }}
+{{- if .Values.prometheus.webhooks.serviceMonitor.relabellings}}
+WARNING - prometheus.webhooks.serviceMonitor.relabellings is deprecated, please migrate to prometheus.webhooks.serviceMonitor.relabelings instead.
+{{- else }}
+
 For more information on running KEDA, visit:
 https://github.com/kedacore/keda/

--- a/keda/Notes.txt
+++ b/keda/Notes.txt
@@ -18,7 +18,7 @@ Get an overview of the Horizontal Pod Autoscalers (HPA) that KEDA is using behin
   kubectl get hpa [--all-namespaces] [--namespace <namespace>]
 
 {{- if .Values.prometheus.operator.serviceMonitor.relabellings}}
-WARNING - prometheus.metricServer.operator.relabellings is deprecated, please migrate to prometheus.operator.serviceMonitor.relabelings instead.
+WARNING - prometheus.operator.serviceMonitor.relabellings is deprecated, please migrate to prometheus.operator.serviceMonitor.relabelings instead.
 {{- else }}
 {{- if .Values.prometheus.metricServer.serviceMonitor.relabellings}}
 WARNING - prometheus.metricServer.serviceMonitor.relabellings is deprecated, please migrate to prometheus.metricServer.serviceMonitor.relabelings instead.

--- a/keda/templates/manager/servicemonitor.yaml
+++ b/keda/templates/manager/servicemonitor.yaml
@@ -38,13 +38,13 @@ spec:
     {{- with .Values.prometheus.operator.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ . }}
     {{- end }}
-  {{- if .Values.prometheus.metricServer.serviceMonitor.relabelings}}
-    {{- with .Values.prometheus.metricServer.serviceMonitor.relabelings }}
+  {{- if .Values.prometheus.operator.serviceMonitor.relabelings}}
+    {{- with .Values.prometheus.operator.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml . | nindent 6 }}
     {{- end }}
   {{- else }}
-    {{- with .Values.prometheus.metricServer.serviceMonitor.relabellings }}
+    {{- with .Values.prometheus.operator.serviceMonitor.relabellings }}
     relabelings:
     {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/keda/templates/webhooks/servicemonitor.yaml
+++ b/keda/templates/webhooks/servicemonitor.yaml
@@ -39,13 +39,13 @@ spec:
     {{- with .Values.prometheus.webhooks.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ . }}
     {{- end }}
-  {{- if .Values.prometheus.metricServer.serviceMonitor.relabelings}}
-    {{- with .Values.prometheus.metricServer.serviceMonitor.relabelings }}
+  {{- if .Values.prometheus.webhooks.serviceMonitor.relabelings}}
+    {{- with .Values.prometheus.webhooks.serviceMonitor.relabelings }}
     relabelings:
     {{- toYaml . | nindent 6 }}
     {{- end }}
   {{- else }}
-    {{- with .Values.prometheus.metricServer.serviceMonitor.relabellings }}
+    {{- with .Values.prometheus.webhooks.serviceMonitor.relabellings }}
     relabelings:
     {{- toYaml . | nindent 6 }}
     {{- end }}


### PR DESCRIPTION
Improve deprecation for service monitor relabelings and fix earlier copy/paste mistake.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to https://github.com/kedacore/charts/issues/457
