### PR TITLE
fix:(http-add-on): chart cli args mismatch

### DIFF
--- a/http-add-on/templates/deployment-operator.yaml
+++ b/http-add-on/templates/deployment-operator.yaml
@@ -48,8 +48,8 @@ spec:
               memory: 20Mi
         name: kube-rbac-proxy
       - args:
-        - --metrics-addr=127.0.0.1:8080
-        - --enable-leader-election
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
         - --admin-port={{ .Values.operator.adminPort }}
         image: "{{ .Values.images.operator }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         imagePullPolicy: '{{ .Values.operator.pullPolicy | default "Always" }}'


### PR DESCRIPTION
There's a regression in the latest chart release (0.5.1) and the error output suggested a simple change would fix it (twice)

```
flag provided but not defined: -enable-leader-election
Usage of /sbin/init:
  -admin-port int
    	The port on which to run the admin server. This is the port on which RPCs will be accepted to get the routing table (default 9090)
  -health-probe-bind-address string
    	The address the probe endpoint binds to. (default ":8081")
  -kubeconfig string
    	Paths to a kubeconfig. Only required if out-of-cluster.
  -leader-elect
    	Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
  -metrics-bind-address string
    	The address the metric endpoint binds to. (default ":8080")
```

The similar error for metrics-addr, I tested this change locally (and everything seems fine after changing these two command line args to be in line with the latest app release!)

I'll check my DCO and rebase to sign-off if needed, I just wanted to upstream this since I found it.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
