### PR TITLE
fix(core): Add missing ASCII art

### DIFF
--- a/keda/templates/NOTES.txt
+++ b/keda/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if .Values.asciiArt }}
 :::^.     .::::^:     :::::::::::::::    .:::::::::.                   .^.                  
 7???~   .^7????~.     7??????????????.   :?????????77!^.              .7?7.                 
 7???~  ^7???7~.       ~!!!!!!!!!!!!!!.   :????!!!!7????7~.           .7???7.                
@@ -14,7 +15,8 @@
                                                                       P@B^                   
                                                                     :&G:                    
                                                                     !5.                     
-                                                                    .            
+                                                                    .        
+{{- end -}}    
 
 Kubernetes Event-driven Autoscaling (KEDA) - Application autoscaling made simple.
 

--- a/keda/templates/NOTES.txt
+++ b/keda/templates/NOTES.txt
@@ -38,17 +38,23 @@ Get an overview of the Horizontal Pod Autoscalers (HPA) that KEDA is using behin
   kubectl get hpa [--all-namespaces] [--namespace <namespace>]
 
 {{- if .Values.prometheus.operator.serviceMonitor.relabellings}}
+-------------------------------------------------------------------------------------
 WARNING - prometheus.operator.serviceMonitor.relabellings is deprecated, please migrate to prometheus.operator.serviceMonitor.relabelings instead.
+-------------------------------------------------------------------------------------
 {{- end }}
 {{- if .Values.prometheus.metricServer.serviceMonitor.relabellings}}
 WARNING - prometheus.metricServer.serviceMonitor.relabellings is deprecated, please migrate to prometheus.metricServer.serviceMonitor.relabelings instead.
 {{- end }}
 {{- if .Values.prometheus.webhooks.serviceMonitor.relabellings}}
+-------------------------------------------------------------------------------------
 WARNING - prometheus.webhooks.serviceMonitor.relabellings is deprecated, please migrate to prometheus.webhooks.serviceMonitor.relabelings instead.
+-------------------------------------------------------------------------------------
 {{- end }}
 
 {{- if lt .Capabilities.KubeVersion.Minor "25" }}
+-------------------------------------------------------------------------------------
 WARNING - Running on unsupported Kubernetes version "1.{{.Capabilities.KubeVersion.Minor}}". KEDA 2.11 is supported and tested on Kubernetes "1.25" or higher. See https://keda.sh/docs/2.11/operate/cluster/ for details.
+-------------------------------------------------------------------------------------
 {{- end }}
 
 Learn more about KEDA:

--- a/keda/templates/NOTES.txt
+++ b/keda/templates/NOTES.txt
@@ -1,6 +1,25 @@
-=====================================================================================
-KEDA - Kubernetes Event Driven Autoscaling
-=====================================================================================
+:::^.     .::::^:     :::::::::::::::    .:::::::::.                   .^.                  
+7???~   .^7????~.     7??????????????.   :?????????77!^.              .7?7.                 
+7???~  ^7???7~.       ~!!!!!!!!!!!!!!.   :????!!!!7????7~.           .7???7.                
+7???~^7????~.                            :????:    :~7???7.         :7?????7.               
+7???7????!.           ::::::::::::.      :????:      .7???!        :7??77???7.              
+7????????7:           7???????????~      :????:       :????:      :???7?5????7.             
+7????!~????^          !77777777777^      :????:       :????:     ^???7?#P7????7.            
+7???~  ^????~                            :????:      :7???!     ^???7J#@J7?????7.           
+7???~   :7???!.                          :????:   .:~7???!.    ~???7Y&@#7777????7.          
+7???~    .7???7:      !!!!!!!!!!!!!!!    :????7!!77????7^     ~??775@@@GJJYJ?????7.         
+7???~     .!????^     7?????????????7.   :?????????7!~:      !????G@@@@@@@@5??????7:        
+::::.       :::::     :::::::::::::::    .::::::::..        .::::JGGGB@@@&7:::::::::        
+                                                                      ?@@#~                  
+                                                                      P@B^                   
+                                                                    :&G:                    
+                                                                    !5.                     
+                                                                    .            
+
+Kubernetes Event-driven Autoscaling (KEDA) - Application autoscaling made simple.
+
+# Getting Started
+
 Get started by deploying Scaled Objects to your cluster:
     - Information about Scaled Objects : https://keda.sh/docs/latest/concepts/
     - Samples: https://github.com/kedacore/samples
@@ -20,8 +39,6 @@ Get details about a deployed ScaledObject:
 Get an overview of the Horizontal Pod Autoscalers (HPA) that KEDA is using behind the scenes:
   kubectl get hpa [--all-namespaces] [--namespace <namespace>]
 
--------------------------------------------------------------------------------------
-
 {{- if .Values.prometheus.operator.serviceMonitor.relabellings}}
 WARNING - prometheus.operator.serviceMonitor.relabellings is deprecated, please migrate to prometheus.operator.serviceMonitor.relabelings instead.
 {{- end }}
@@ -32,11 +49,13 @@ WARNING - prometheus.metricServer.serviceMonitor.relabellings is deprecated, ple
 WARNING - prometheus.webhooks.serviceMonitor.relabellings is deprecated, please migrate to prometheus.webhooks.serviceMonitor.relabelings instead.
 {{- end }}
 
-
 {{- if lt .Capabilities.KubeVersion.Minor "25" }}
 WARNING - Running on unsupported Kubernetes version "1.{{.Capabilities.KubeVersion.Minor}}". KEDA 2.11 is supported and tested on Kubernetes "1.25" or higher. See https://keda.sh/docs/2.11/operate/cluster/ for details.
 {{- end }}
 
-For more information on running KEDA, visit: 
-https://github.com/kedacore/keda/
-=====================================================================================
+# Learn More
+
+Learn more about KEDA:
+- Documentation: https://keda.sh/
+- Support: https://keda.sh/support/
+- File an issue: https://github.com/kedacore/keda/issues/new/choose

--- a/keda/templates/NOTES.txt
+++ b/keda/templates/NOTES.txt
@@ -18,8 +18,6 @@
 
 Kubernetes Event-driven Autoscaling (KEDA) - Application autoscaling made simple.
 
-# Getting Started
-
 Get started by deploying Scaled Objects to your cluster:
     - Information about Scaled Objects : https://keda.sh/docs/latest/concepts/
     - Samples: https://github.com/kedacore/samples
@@ -52,8 +50,6 @@ WARNING - prometheus.webhooks.serviceMonitor.relabellings is deprecated, please 
 {{- if lt .Capabilities.KubeVersion.Minor "25" }}
 WARNING - Running on unsupported Kubernetes version "1.{{.Capabilities.KubeVersion.Minor}}". KEDA 2.11 is supported and tested on Kubernetes "1.25" or higher. See https://keda.sh/docs/2.11/operate/cluster/ for details.
 {{- end }}
-
-# Learn More
 
 Learn more about KEDA:
 - Documentation: https://keda.sh/

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -629,3 +629,6 @@ extraObjects: []
   #   spec:
   #     podIdentity:
   #       provider: aws-eks
+
+# -- Capability to turn on/off ASCII art in Helm installation notes
+asciiArt: true


### PR DESCRIPTION
Improve Helm notes a bit to make it more end-user friendly and add missing ASCII art:

```
:::^.     .::::^:     :::::::::::::::    .:::::::::.                   .^.
7???~   .^7????~.     7??????????????.   :?????????77!^.              .7?7.
7???~  ^7???7~.       ~!!!!!!!!!!!!!!.   :????!!!!7????7~.           .7???7.
7???~^7????~.                            :????:    :~7???7.         :7?????7.
7???7????!.           ::::::::::::.      :????:      .7???!        :7??77???7.
7????????7:           7???????????~      :????:       :????:      :???7?5????7.
7????!~????^          !77777777777^      :????:       :????:     ^???7?#P7????7.
7???~  ^????~                            :????:      :7???!     ^???7J#@J7?????7.
7???~   :7???!.                          :????:   .:~7???!.    ~???7Y&@#7777????7.
7???~    .7???7:      !!!!!!!!!!!!!!!    :????7!!77????7^     ~??775@@@GJJYJ?????7.
7???~     .!????^     7?????????????7.   :?????????7!~:      !????G@@@@@@@@5??????7:
::::.       :::::     :::::::::::::::    .::::::::..        .::::JGGGB@@@&7:::::::::
                                                                      ?@@#~
                                                                      P@B^
                                                                    :&G:
                                                                    !5.
                                                                    .

Kubernetes Event-driven Autoscaling (KEDA) - Application autoscaling made simple.

Get started by deploying Scaled Objects to your cluster:
    - Information about Scaled Objects : https://keda.sh/docs/latest/concepts/
    - Samples: https://github.com/kedacore/samples

Get information about the deployed ScaledObjects:
  kubectl get scaledobject [--namespace <namespace>]

Get details about a deployed ScaledObject:
  kubectl describe scaledobject <scaled-object-name> [--namespace <namespace>]

Get information about the deployed ScaledObjects:
  kubectl get triggerauthentication [--namespace <namespace>]

Get details about a deployed ScaledObject:
  kubectl describe triggerauthentication <trigger-authentication-name> [--namespace <namespace>]

Get an overview of the Horizontal Pod Autoscalers (HPA) that KEDA is using behind the scenes:
  kubectl get hpa [--all-namespaces] [--namespace <namespace>]

Learn more about KEDA:
- Documentation: https://keda.sh/
- Support: https://keda.sh/support/
- File an issue: https://github.com/kedacore/keda/issues/new/choose
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
