### PR TITLE
Updating templates to remove blank annotations

### DIFF
--- a/keda/templates/cert-manager/keda-issuer.yaml
+++ b/keda/templates/cert-manager/keda-issuer.yaml
@@ -2,8 +2,10 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ .Values.operator.name }}-issuer
   namespace: {{ .Release.Namespace }}
 spec:

--- a/keda/templates/cert-manager/self-issuer.yaml
+++ b/keda/templates/cert-manager/self-issuer.yaml
@@ -2,8 +2,10 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ .Values.operator.name }}-selfsigned-issuer
   namespace: {{ .Release.Namespace }}
 spec:

--- a/keda/templates/manager/clusterrole.yaml
+++ b/keda/templates/manager/clusterrole.yaml
@@ -2,8 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/manager/clusterrolebinding.yaml
+++ b/keda/templates/manager/clusterrolebinding.yaml
@@ -2,8 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -3,8 +3,10 @@ kind: Deployment
 metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ .Values.operator.name }}
     name: {{ .Values.operator.name }}
@@ -35,6 +37,7 @@ spec:
         {{- if .Values.podIdentity.azureWorkload.enabled }}
         azure.workload.identity/use: "true"
         {{- end }}
+      {{- if or .Values.podAnnotations.keda .Values.additionalAnnotations }}
       annotations:
         {{- if .Values.podAnnotations.keda }}
         {{- toYaml .Values.podAnnotations.keda | nindent 8 }}
@@ -42,6 +45,7 @@ spec:
         {{- if .Values.additionalAnnotations }}
         {{- toYaml .Values.additionalAnnotations | nindent 8 }}
         {{- end }}
+      {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/keda/templates/manager/poddisruptionbudget.yaml
+++ b/keda/templates/manager/poddisruptionbudget.yaml
@@ -4,8 +4,10 @@ kind: PodDisruptionBudget
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Values.operator.name }}
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.serviceAccount.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/manager/podmonitor.yaml
+++ b/keda/templates/manager/podmonitor.yaml
@@ -3,8 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ .Values.operator.name }}
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/manager/prometheusrules.yaml
+++ b/keda/templates/manager/prometheusrules.yaml
@@ -3,8 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ .Values.operator.name }}
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/manager/role.yaml
+++ b/keda/templates/manager/role.yaml
@@ -2,8 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/manager/rolebinding.yaml
+++ b/keda/templates/manager/rolebinding.yaml
@@ -2,8 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/manager/service.yaml
+++ b/keda/templates/manager/service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if or .Values.additionalAnnotations .Values.service.annotations (and .Values.prometheus.operator.enabled ( not (or .Values.prometheus.operator.podMonitor.enabled .Values.prometheus.operator.serviceMonitor.enabled ))) }}
   annotations:
     {{- if and .Values.prometheus.operator.enabled ( not (or .Values.prometheus.operator.podMonitor.enabled .Values.prometheus.operator.serviceMonitor.enabled )) }}
     prometheus.io/scrape: "true"
@@ -17,6 +18,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
       {{- end }}
     {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/manager/servicemonitor.yaml
+++ b/keda/templates/manager/servicemonitor.yaml
@@ -3,8 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Values.operator.name }}
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/metrics-server/apiservice.yaml
+++ b/keda/templates/metrics-server/apiservice.yaml
@@ -1,6 +1,7 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
+  {{- if or .Values.certificates.certManager.enabled .Values.additionalAnnotations }}
   annotations:
     {{- if .Values.certificates.certManager.enabled }}
     {{- if .Values.certificates.certManager.generateCA }}
@@ -12,6 +13,7 @@ metadata:
     {{- if .Values.additionalAnnotations }}
     {{- toYaml .Values.additionalAnnotations | nindent 4 }}
     {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: v1beta1.external.metrics.k8s.io
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/metrics-server/clusterrole.yaml
+++ b/keda/templates/metrics-server/clusterrole.yaml
@@ -2,8 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}-external-metrics-reader
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/metrics-server/clusterrolebinding.yaml
+++ b/keda/templates/metrics-server/clusterrolebinding.yaml
@@ -2,8 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}-system-auth-delegator
     {{- include "keda.labels" . | indent 4 }}
@@ -20,8 +22,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}-auth-reader
     {{- include "keda.labels" . | indent 4 }}
@@ -39,8 +43,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}-hpa-controller-external-metrics
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -3,8 +3,10 @@ kind: Deployment
 metadata:
   name: {{ .Values.operator.name }}-metrics-apiserver
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ .Values.operator.name }}-metrics-apiserver
     app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver
@@ -33,6 +35,7 @@ spec:
         {{- if .Values.podIdentity.azureWorkload.enabled }}
         azure.workload.identity/use: "true"
         {{- end }}
+      {{- if or .Values.additionalAnnotations .Values.podAnnotations.metricsAdapter (and .Values.prometheus.metricServer.enabled ( not (or .Values.prometheus.metricServer.podMonitor.enabled .Values.prometheus.metricServer.serviceMonitor.enabled )) )}}
       annotations:
         {{- if .Values.additionalAnnotations }}
         {{- toYaml .Values.additionalAnnotations | nindent 8 }}
@@ -45,6 +48,7 @@ spec:
         {{- if .Values.podAnnotations.metricsAdapter }}
         {{- toYaml .Values.podAnnotations.metricsAdapter | nindent 8}}
         {{- end }}
+      {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/keda/templates/metrics-server/poddisruptionbudget.yaml
+++ b/keda/templates/metrics-server/poddisruptionbudget.yaml
@@ -4,8 +4,10 @@ kind: PodDisruptionBudget
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Values.operator.name }}-metrics-apiserver
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/metrics-server/podmonitor.yaml
+++ b/keda/templates/metrics-server/podmonitor.yaml
@@ -3,8 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ .Values.operator.name }}-metrics-apiserver
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/metrics-server/service.yaml
+++ b/keda/templates/metrics-server/service.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- include "keda.labels" . | indent 4 }}
   name: {{ .Values.operator.name }}-metrics-apiserver
   namespace: {{ .Release.Namespace }}
+  {{- if or .Values.additionalAnnotations .Values.service.annotations (and .Values.prometheus.metricServer.enabled ( not (or .Values.prometheus.metricServer.podMonitor.enabled .Values.prometheus.metricServer.serviceMonitor.enabled )))}}
   annotations:
     {{- if and .Values.prometheus.metricServer.enabled ( not (or .Values.prometheus.metricServer.podMonitor.enabled .Values.prometheus.metricServer.serviceMonitor.enabled )) }}
     prometheus.io/scrape: "true"
@@ -23,6 +24,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
       {{- end }}
     {{- end }}
+  {{- end }}
 spec:
   ports:
   - name: https

--- a/keda/templates/metrics-server/servicemonitor.yaml
+++ b/keda/templates/metrics-server/servicemonitor.yaml
@@ -3,8 +3,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Values.operator.name }}-metrics-apiserver
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -4,8 +4,10 @@ kind: Deployment
 metadata:
   name: {{ .Values.webhooks.name }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app: {{ .Values.webhooks.name }}
     name: {{ .Values.webhooks.name }}
@@ -30,6 +32,7 @@ spec:
         {{- if .Values.podLabels.webhooks }}
         {{- toYaml .Values.podLabels.webhooks | nindent 8 }}
         {{- end }}
+      {{- if or .Values.podAnnotations.webhooks .Values.additionalAnnotations }}
       annotations:
         {{- if .Values.podAnnotations.webhooks }}
         {{- toYaml .Values.podAnnotations.webhooks | nindent 8 }}
@@ -37,6 +40,7 @@ spec:
         {{- if .Values.additionalAnnotations }}
         {{- toYaml .Values.additionalAnnotations | nindent 8 }}
         {{- end }}
+      {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/keda/templates/webhooks/poddisruptionbudget.yaml
+++ b/keda/templates/webhooks/poddisruptionbudget.yaml
@@ -5,8 +5,10 @@ kind: PodDisruptionBudget
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ .Values.webhooks.name }}
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.serviceAccount.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/webhooks/prometheusrules.yaml
+++ b/keda/templates/webhooks/prometheusrules.yaml
@@ -4,8 +4,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ .Values.webhooks.name }}
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.webhooks.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/webhooks/service.yaml
+++ b/keda/templates/webhooks/service.yaml
@@ -2,6 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if or .Values.prometheus.webhooks.enabled .Values.additionalAnnotations .Values.service.annotations }}
   annotations:
     {{- if and .Values.prometheus.webhooks.enabled ( not .Values.prometheus.webhooks.serviceMonitor.enabled ) }}
     prometheus.io/scrape: "true"
@@ -18,6 +19,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
       {{- end }}
     {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.webhooks.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/webhooks/servicemonitor.yaml
+++ b/keda/templates/webhooks/servicemonitor.yaml
@@ -4,8 +4,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Values.webhooks.name }}
+  {{- with .Values.additionalAnnotations }}
   annotations:
-    {{- toYaml .Values.additionalAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.webhooks.name }}
     {{- include "keda.labels" . | indent 4 }}

--- a/keda/templates/webhooks/validatingconfiguration.yaml
+++ b/keda/templates/webhooks/validatingconfiguration.yaml
@@ -2,6 +2,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  {{- if or .Values.certificates.certManager.enabled .Values.additionalAnnotations }}
   annotations:
     {{- if .Values.certificates.certManager.enabled }}
     {{- if .Values.certificates.certManager.generateCA }}
@@ -13,6 +14,7 @@ metadata:
     {{- if .Values.additionalAnnotations }}
     {{- toYaml .Values.additionalAnnotations | nindent 4 }}
     {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.webhooks.name }}
     {{- include "keda.labels" . | indent 4 }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

When using the keda chart, I noticed that annotations can generate empty key's when no additional annotations are passed in e.g.
```
# Source: keda/templates/manager/service.yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
  labels:
    app.kubernetes.io/name: keda-operator    
    helm.sh/chart: keda-2.11.0
    app.kubernetes.io/component: operator
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/part-of: keda-operator
    app.kubernetes.io/version: 2.11.0
  name: keda-operator
  namespace: default
spec:
  ports:
  - name: metricsservice
    port: 9666
    targetPort: 9666
  selector:
    app: keda-operator
---
```

I am attempted to just alter the helm template logic to only create the annotation key should there be a value passed in. I have added a before and after yaml from running `helm template` locally. I carried out some local testing where I passed in a number of different values (i.e. not just `AdditionalAnnotations`) and seemed ok to me.


### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #

Files for comparison:
[beforeAfter.zip](https://github.com/kedacore/charts/files/11851443/beforeAfter.zip)

