### PR TITLE
Removing MS-apiserver MS path

### DIFF
--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -40,7 +40,6 @@ spec:
         {{- if and .Values.prometheus.metricServer.enabled ( not (or .Values.prometheus.metricServer.podMonitor.enabled .Values.prometheus.metricServer.serviceMonitor.enabled )) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.metricServer.port | quote }}
-        prometheus.io/path: {{ .Values.prometheus.metricServer.path }}
         {{- end }}
         {{- if .Values.podAnnotations.metricsAdapter }}
         {{- toYaml .Values.podAnnotations.metricsAdapter | nindent 8}}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

#488 investigation, looks like this may have been missed as part of [this](https://github.com/kedacore/charts/pull/432/files#diff-cef26632adc4078d60a55b5799578907d1f409eb9f2cfd1910b4974ebc87185dL43) - [this](https://github.com/kubernetes-sigs/metrics-server/blob/master/docs/command-line-flags.txt) I think its safe to remove that extra field. 

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
#488