### PR TITLE
fix(keda): Remove unnecesary condition for setting prometheus port in webhooks

### DIFF
--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -77,9 +77,7 @@ spec:
           {{- if .Values.webhooks.port }}
           - "--port={{ .Values.webhooks.port }}"
           {{- end }}
-          {{- if .Values.prometheus.webhooks.enabled }}
           - --metrics-bind-address=:{{ .Values.prometheus.webhooks.port }}
-          {{- end }}
           {{- range $key, $value := .Values.extraArgs.webhooks }}
           - --{{ $key }}={{ $value }}
           {{- end }}


### PR DESCRIPTION
Webhooks prometheus port already has a default value, so doesn't make sense to check if it's enabled or not to override the value, considering that it doesn't disable the server (which would need to set 0 instead of the default value)

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Related to https://github.com/kedacore/keda/issues/4777
