### PR TITLE
chore: Remove all non-editable keys from resources

### DIFF
--- a/http-add-on/templates/crd.yaml
+++ b/http-add-on/templates/crd.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   name: httpscaledobjects.http.keda.sh
 spec:
   group: http.keda.sh

--- a/http-add-on/templates/rbac-interceptor.yml
+++ b/http-add-on/templates/rbac-interceptor.yml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
     httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}

--- a/http-add-on/templates/rbac-operator.yml
+++ b/http-add-on/templates/rbac-operator.yml
@@ -34,7 +34,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
     httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
@@ -86,7 +85,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
     httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}

--- a/http-add-on/templates/rbac-scaler.yml
+++ b/http-add-on/templates/rbac-scaler.yml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
     httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}

--- a/keda/templates/manager/clusterrole.yaml
+++ b/keda/templates/manager/clusterrole.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}
-  creationTimestamp: null
   name: {{ .Values.operator.name }}
 rules:
 - apiGroups:

--- a/keda/templates/manager/role.yaml
+++ b/keda/templates/manager/role.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}
-  creationTimestamp: null
   name: {{ .Values.operator.name }}
   namespace: {{ .Release.Namespace }}
 rules:

--- a/keda/templates/metrics-server/clusterrole.yaml
+++ b/keda/templates/metrics-server/clusterrole.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}-external-metrics-reader
     {{- include "keda.labels" . | indent 4 }}
-  creationTimestamp: null
   name: {{ .Values.operator.name }}-external-metrics-reader
 rules:
 - apiGroups:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

The field `creationTimestamp` is auto-generated by kubernetes. This field is ignored during creation/update because it's non-editable by clients.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

