### PR TITLE
Show only logs with a severity level of ERROR or higher in the stderr

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -141,6 +141,7 @@ their default values.
 | `image.metricsApiServer.repository` | string | `"ghcr.io/kedacore/keda-metrics-apiserver"` | Image name of KEDA Metrics API Server |
 | `image.metricsApiServer.tag` | string | `""` | Image tag of KEDA Metrics API Server. Optional, given app version of Helm chart is used by default |
 | `logging.metricServer.level` | int | `0` | Logging level for Metrics Server. allowed values: `0` for info, `4` for debug, or an integer value greater than 0, specified as string |
+| `logging.metricServer.stderrthreshold` | string | `"ERROR"` | Logging stderrthreshold for Metrics Server allowed values: 'DEBUG','INFO','WARN','ERROR','ALERT','EMERG' |
 | `metricsServer.affinity` | object | `{}` | [Affinity] for pod scheduling for Metrics API Server. Takes precedence over the `affinity` field |
 | `metricsServer.dnsPolicy` | string | `"ClusterFirst"` | Defined the DNS policy for the metric server |
 | `metricsServer.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -121,7 +121,7 @@ spec:
           - /usr/local/bin/keda-adapter
           - --port={{ .Values.prometheus.metricServer.port }}
           - --secure-port={{ .Values.service.portHttpsTarget }}
-          - --logtostderr=true
+          - --stderrthreshold=ERROR
           - --metrics-service-address={{ .Values.operator.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:9666
           - --client-ca-file={{ .Values.certificates.mountPath }}/ca.crt
           - --tls-cert-file={{ .Values.certificates.mountPath }}/tls.crt

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -122,7 +122,7 @@ spec:
           - --port={{ .Values.prometheus.metricServer.port }}
           - --secure-port={{ .Values.service.portHttpsTarget }}
           - --logtostderr=true
-          - --stderrthreshold=ERROR
+          - --stderrthreshold={{ .Values.logging.metricServer.stderrthreshold }}
           - --metrics-service-address={{ .Values.operator.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:9666
           - --client-ca-file={{ .Values.certificates.mountPath }}/ca.crt
           - --tls-cert-file={{ .Values.certificates.mountPath }}/tls.crt

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -121,6 +121,7 @@ spec:
           - /usr/local/bin/keda-adapter
           - --port={{ .Values.prometheus.metricServer.port }}
           - --secure-port={{ .Values.service.portHttpsTarget }}
+          - --logtostderr=true
           - --stderrthreshold=ERROR
           - --metrics-service-address={{ .Values.operator.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:9666
           - --client-ca-file={{ .Values.certificates.mountPath }}/ca.crt

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -305,7 +305,9 @@ logging:
     # -- Logging level for Metrics Server.
     # allowed values: `0` for info, `4` for debug, or an integer value greater than 0, specified as string
     level: 0
-
+    # -- Logging stderrthreshold for Metrics Server
+    # allowed values: 'DEBUG','INFO','WARN','ERROR','ALERT','EMERG'
+    stderrthreshold: ERROR
   webhooks:
     # -- Logging level for KEDA Operator.
     # allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string


### PR DESCRIPTION
Signed-off-by: Adarsh-verma-14 [t_adarsh.verma@india.nec.com](mailto:t_adarsh.verma@india.nec.com)

Add one deployment arg in keda-metrics-apiserver for show only log messages with a severity level of ERROR or higher in the stderr

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))



