### PR TITLE
remove namespace from webhook

### DIFF
--- a/keda/templates/webhooks/validatingconfiguration.yaml
+++ b/keda/templates/webhooks/validatingconfiguration.yaml
@@ -19,7 +19,6 @@ metadata:
     app.kubernetes.io/name: {{ .Values.webhooks.name }}
     {{- include "keda.labels" . | indent 4 }}
   name: keda-admission
-  namespace: {{ .Release.Namespace }}
 webhooks:
 - admissionReviewVersions:
   - v1


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Remove unnecessary `namespace` from metadata since ValidatingWebhookConfiguration is a cluster scoped resource.

### Checklist


Fixes #
