### PR TITLE
Allow user to set custom `livenessProbe` and `readinessProbe`

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -116,7 +116,9 @@ their default values.
 | `logging.operator.level` | string | `"info"` | Logging level for KEDA Operator. allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string |
 | `logging.operator.timeEncoding` | string | `"rfc3339"` | Logging time encoding for KEDA Operator. allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano` |
 | `operator.affinity` | object | `{}` | [Affinity] for pod scheduling for KEDA operator. Takes precedence over the `affinity` field |
+| `operator.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":25,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `operator.name` | string | `"keda-operator"` | Name of the KEDA operator |
+| `operator.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":20,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |
 | `operator.replicaCount` | int | `1` | Capability to configure the number of replicas for KEDA operator. While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover. Learn more in [our documentation](https://keda.sh/docs/latest/operate/cluster/#high-availability). |
 | `permissions.operator.restrict.secret` | bool | `false` | Restrict Secret Access for KEDA operator |
 | `podAnnotations.keda` | object | `{}` | Pod annotations for KEDA operator |
@@ -163,6 +165,8 @@ their default values.
 | `logging.metricServer.level` | int | `0` | Logging level for Metrics Server. allowed values: `0` for info, `4` for debug, or an integer value greater than 0, specified as string |
 | `metricsServer.affinity` | object | `{}` | [Affinity] for pod scheduling for Metrics API Server. Takes precedence over the `affinity` field |
 | `metricsServer.dnsPolicy` | string | `"ClusterFirst"` | Defined the DNS policy for the metric server |
+| `metricsServer.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
+| `metricsServer.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |
 | `metricsServer.replicaCount` | int | `1` | Capability to configure the number of replicas for KEDA metric server. While you can run more replicas of our metric server, only one instance will used and serve traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover. Learn more in [our documentation](https://keda.sh/docs/latest/operate/cluster/#high-availability). |
 | `metricsServer.useHostNetwork` | bool | `false` | Enable metric server to use host network |
 | `permissions.metricServer.restrict.secret` | bool | `false` | Restrict Secret Access for Metrics Server |
@@ -241,8 +245,10 @@ their default values.
 | `webhooks.enabled` | bool | `true` | Enable admission webhooks (this feature option will be removed in v2.12) |
 | `webhooks.failurePolicy` | string | `"Ignore"` | [Failure policy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) to use with KEDA admission webhooks |
 | `webhooks.healthProbePort` | int | `8081` | Port number to use for KEDA admission webhooks health probe |
+| `webhooks.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":25,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for admission webhooks ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `webhooks.name` | string | `"keda-admission-webhooks"` | Name of the KEDA admission webhooks |
 | `webhooks.port` | string | `""` | Port number to use for KEDA admission webhooks. Default is 9443. |
+| `webhooks.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":20,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for admission webhooks ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |
 | `webhooks.replicaCount` | int | `1` | Capability to configure the number of replicas for KEDA admission webhooks |
 | `webhooks.useHostNetwork` | bool | `false` | Enable webhook to use host network, this is required on EKS with custom CNI |
 

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -95,12 +95,20 @@ spec:
             httpGet:
               path: /healthz
               port: 8081
-            initialDelaySeconds: 25
+            initialDelaySeconds: {{ .Values.operator.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.operator.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.operator.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.operator.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.operator.livenessProbe.successThreshold }}
           readinessProbe:
             httpGet:
               path: /readyz
               port: 8081
-            initialDelaySeconds: 20
+            initialDelaySeconds: {{ .Values.operator.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.operator.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.operator.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.operator.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.operator.readinessProbe.successThreshold }}
           ports:
           - containerPort: 8080
             name: http

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -79,13 +79,21 @@ spec:
               path: /healthz
               port: {{ .Values.service.portHttpsTarget }}
               scheme: HTTPS
-            initialDelaySeconds: 5
+            initialDelaySeconds: {{ .Values.metricsServer.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metricsServer.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metricsServer.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.metricsServer.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.metricsServer.livenessProbe.successThreshold }}
           readinessProbe:
             httpGet:
               path: /readyz
               port: {{ .Values.service.portHttpsTarget }}
               scheme: HTTPS
-            initialDelaySeconds: 5
+            initialDelaySeconds: {{ .Values.metricsServer.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metricsServer.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metricsServer.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.metricsServer.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.metricsServer.readinessProbe.successThreshold }}
           env:
             - name: WATCH_NAMESPACE
               value: {{ .Values.watchNamespace | quote }}

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -86,12 +86,20 @@ spec:
             httpGet:
               path: /healthz
               port: {{ .Values.webhooks.healthProbePort }}
-            initialDelaySeconds: 25
+            initialDelaySeconds: {{ .Values.webhooks.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webhooks.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.webhooks.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.webhooks.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.webhooks.livenessProbe.successThreshold }}
           readinessProbe:
             httpGet:
               path: /readyz
               port: {{ .Values.webhooks.healthProbePort }}
-            initialDelaySeconds: 20
+            initialDelaySeconds: {{ .Values.webhooks.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webhooks.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.webhooks.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.webhooks.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.webhooks.readinessProbe.successThreshold }}
           ports:
           - containerPort: {{ .Values.webhooks.port | default 9443 }}
             name: http

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -53,6 +53,20 @@ operator:
     #         values:
     #         - keda-operator
     #     topologyKey: "kubernetes.io/hostname"
+  # -- Liveness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/))
+  livenessProbe:
+    initialDelaySeconds: 25
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  # -- Readiness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes))
+  readinessProbe:
+    initialDelaySeconds: 20
+    periodSeconds: 3
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
 
 metricsServer:
   # -- Capability to configure the number of replicas for KEDA metric server.
@@ -76,6 +90,20 @@ metricsServer:
     #         values:
     #         - keda-operator-metrics-apiserver
     #     topologyKey: "kubernetes.io/hostname"
+  # -- Liveness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/))
+  livenessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  # -- Readiness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes))
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 3
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
 
 webhooks:
   # -- Enable admission webhooks (this feature option will be removed in v2.12)
@@ -84,6 +112,20 @@ webhooks:
   port: ""
   # -- Port number to use for KEDA admission webhooks health probe
   healthProbePort: 8081
+  # -- Liveness probes for admission webhooks ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/))
+  livenessProbe:
+    initialDelaySeconds: 25
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  # -- Readiness probes for admission webhooks ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes))
+  readinessProbe:
+    initialDelaySeconds: 20
+    periodSeconds: 3
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
   # -- Enable webhook to use host network, this is required on EKS with custom CNI
   useHostNetwork: false
   # -- Name of the KEDA admission webhooks


### PR DESCRIPTION
Hi team,

This PR allows user to set custom value for livenessProbe and readinessProbe too

_Provide a description of what has been changed_

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes https://github.com/kedacore/charts/issues/508
