### PR TITLE
fix: explicitly set insecureSkipTLSVerify as disabled for upgrades

### DIFF
--- a/keda/templates/metrics-server/apiservice.yaml
+++ b/keda/templates/metrics-server/apiservice.yaml
@@ -27,3 +27,4 @@ spec:
   version: v1beta1
   groupPriorityMinimum: 100
   versionPriority: 100
+  insecureSkipTLSVerify: false


### PR DESCRIPTION
After adding cert-management and removing `insecureSkipTLSVerify`, it seems that during migration from the newer versions, helm doesn't remove the old value (probably because the apiservice doesn't set it explicitly).

To prevent this error, this PR explicitly sets the `insecureSkipTLSVerify: false`. This property can be removed in future versions once enough time has passed since we changed the value.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

