### PR TITLE
fix: add linux node selector to deployments

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         app.kubernetes.io/component: interceptor
         {{- include "keda-http-add-on.labels" . | indent 8 }}
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       imagePullSecrets: 
         {{- toYaml .Values.interceptor.imagePullSecrets | nindent 8 }}
       serviceAccountName: {{ .Chart.Name }}-interceptor

--- a/http-add-on/templates/operator/deployment.yaml
+++ b/http-add-on/templates/operator/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         app.kubernetes.io/component: operator
         {{- include "keda-http-add-on.labels" . | indent 8 }}
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       imagePullSecrets: 
         {{- toYaml .Values.operator.imagePullSecrets | nindent 8 }}
       serviceAccountName: {{ .Chart.Name }}

--- a/http-add-on/templates/scaler/deployment.yaml
+++ b/http-add-on/templates/scaler/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         app.kubernetes.io/component: scaler
         {{- include "keda-http-add-on.labels" . | indent 8 }}
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       imagePullSecrets: 
         {{- toYaml .Values.scaler.imagePullSecrets | nindent 8 }}
       serviceAccountName: {{ .Chart.Name }}-external-scaler

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -48,6 +48,8 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -50,6 +50,8 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -43,6 +43,8 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}


### PR DESCRIPTION
When KEDA is deployed to a mixed Kubernetes cluster with linux and windows nodes, the deployments did not select the linux nodes explicitly and could not be started on windows nodes.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [-] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [-] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
