### PR TITLE
Fix the svc name of webhook to avoid breaking istio

### DIFF
--- a/keda/templates/webhooks/service.yaml
+++ b/keda/templates/webhooks/service.yaml
@@ -27,7 +27,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - name: http
+  - name: https
     port: 443
     protocol: TCP
     targetPort: {{ .Values.webhooks.port | default 9443 }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

This addresses the issue https://github.com/kedacore/charts/issues/500
Only webhook's svc name is `http`, others are fine

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
