### PR TITLE
Fix TriggerAuthentication - added configuration for validation webhook

### DIFF
--- a/keda/templates/webhooks/validatingconfiguration.yaml
+++ b/keda/templates/webhooks/validatingconfiguration.yaml
@@ -44,4 +44,52 @@ webhooks:
     - scaledobjects
   sideEffects: None
   timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.webhooks.name }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-keda-sh-v1alpha1-triggerauthentication
+  failurePolicy: {{ .Values.webhooks.failurePolicy }}
+  matchPolicy: Equivalent
+  name: vstriggerauthentication.kb.io
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - keda.sh
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - triggerauthentications
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ .Values.webhooks.name }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-keda-sh-v1alpha1-clustertriggerauthentication
+  failurePolicy: {{ .Values.webhooks.failurePolicy }}
+  matchPolicy: Equivalent
+  name: vsclustertriggerauthentication.kb.io
+  namespaceSelector: {}
+  objectSelector: {}
+  rules:
+  - apiGroups:
+    - keda.sh
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clustertriggerauthentications
+  sideEffects: None
+  timeoutSeconds: 10
 {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Related to https://github.com/kedacore/keda/pull/4696 

Added missing configuration for validation webhook (TriggerAuthentication)

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Relates to https://github.com/kedacore/keda/issues/5109
