### PR TITLE
Fix Remove app.kubernetes.io/instance label in crd

### DIFF
--- a/keda/templates/_helpers.tpl
+++ b/keda/templates/_helpers.tpl
@@ -8,17 +8,24 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Generate basic labels
+Generate basic labels for CRD
 */}}
-{{- define "keda.labels" }}
+{{- define "keda.crd-labels" }}
 helm.sh/chart: {{ include "keda.chart" . }}
 app.kubernetes.io/component: operator
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/part-of: {{ .Values.operator.name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- end }}
+{{- end }}
+
+{{/*
+Generate basic labels
+*/}}
+{{- define "keda.labels" -}}
+{{- include "keda.crd-labels" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.additionalLabels }}
 {{ toYaml .Values.additionalLabels }}
 {{- end }}

--- a/keda/templates/crds/crd-clustertriggerauthentications.yaml
+++ b/keda/templates/crds/crd-clustertriggerauthentications.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
-    {{- include "keda.labels" . | indent 4 }}
+    {{- include "keda.crd-labels" . | indent 4 }}
   name: clustertriggerauthentications.keda.sh
 spec:
   group: keda.sh

--- a/keda/templates/crds/crd-scaledjobs.yaml
+++ b/keda/templates/crds/crd-scaledjobs.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
-    {{- include "keda.labels" . | indent 4 }}
+    {{- include "keda.crd-labels" . | indent 4 }}
   name: scaledjobs.keda.sh
 spec:
   group: keda.sh

--- a/keda/templates/crds/crd-scaledobjects.yaml
+++ b/keda/templates/crds/crd-scaledobjects.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
-    {{- include "keda.labels" . | indent 4 }}
+    {{- include "keda.crd-labels" . | indent 4 }}
   name: scaledobjects.keda.sh
 spec:
   group: keda.sh

--- a/keda/templates/crds/crd-triggerauthentications.yaml
+++ b/keda/templates/crds/crd-triggerauthentications.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
-    {{- include "keda.labels" . | indent 4 }}
+    {{- include "keda.crd-labels" . | indent 4 }}
   name: triggerauthentications.keda.sh
 spec:
   group: keda.sh


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

When deploying keda with argocd, changing the releasename keep causes a warning in the argocd application. for example,   argocd appplication name is keda-test and releaseName: keda, keep causes a warning

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: keda-test
  namespace: argocd
spec:
  source:
    helm:
      releaseName: keda
```

![keda_warning](https://github.com/kedacore/charts/assets/9348148/1d2f5f0a-ea4e-4f8f-a70f-e9a4d1e545bb)


[Argocd offical document](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#helm-release-name) say that 
`Please note that overriding the Helm release name might cause problems when the chart you are deploying is using the app.kubernetes.io/instance.
`

And, I use [argo rollout helm charts](https://github.com/argoproj/argo-helm/blob/main/charts/argo-rollouts/templates/crds/rollout-crd.yaml#L14), [karpenter helm charts](https://github.com/aws/karpenter/blob/main/pkg/apis/crds/karpenter.sh_machines.yaml#L4) same method. but argocd application has not warning. because these helm charts have no  app.kubernetes.io/instance  label in crd.

So. I think that remove app.kubernetes.io/instance label in crd. thank you.



### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

