### PR TITLE
remove not required insecureSkipTLSVerify

### DIFF
--- a/keda/templates/metrics-server/apiservice.yaml
+++ b/keda/templates/metrics-server/apiservice.yaml
@@ -27,4 +27,3 @@ spec:
   version: v1beta1
   groupPriorityMinimum: 100
   versionPriority: 100
-  insecureSkipTLSVerify: false


### PR DESCRIPTION
As mentioned [here](https://github.com/kedacore/keda/issues/4732) and discussed [here](https://github.com/kedacore/keda/discussions/5123) the setting of `insecureSkipTLSVerify` in apiservice.apiregistration.k8s.io will disturb CI/CD pipelines like ArgoCD or, just in our case, Fleet. The adding of `caBundle` will remove `insecureSkipTLSVerify` automatically in the cluster. Fleet will state in "modified" instead of "active". Removing this field in Helm solves the issue.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes https://github.com/kedacore/keda/issues/4732

hint: Helm has also this [genCa](https://helm.sh/docs/chart_template_guide/function_list/#genca) function to generate certificate
