### PR TITLE
Fix http-add-on operator resources

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -102,6 +102,8 @@ their default values.
 |-----------|------|---------|-------------|
 | `operator.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
 | `operator.imagePullSecrets` | list | `[]` | The image pull secrets for the operator component |
+| `operator.kubeRbacProxy.resources.limits` | object | `{"cpu":"300m","memory":"200Mi"}` | The CPU/memory resource limit for the operator component's kube rbac proxy |
+| `operator.kubeRbacProxy.resources.requests` | object | `{"cpu":"10m","memory":"20Mi"}` | The CPU/memory resource request for the operator component's kube rbac proxy |
 | `operator.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |
 | `operator.port` | int | `8443` | The port for the operator main server to run on |
 | `operator.pullPolicy` | string | `"Always"` | The image pull policy for the operator component |

--- a/http-add-on/templates/operator/deployment.yaml
+++ b/http-add-on/templates/operator/deployment.yaml
@@ -37,12 +37,7 @@ spec:
         image: "{{ .Values.images.kubeRbacProxy.name }}:{{ .Values.images.kubeRbacProxy.tag }}"
         name: kube-rbac-proxy
         resources:
-            limits:
-              cpu: 300m
-              memory: 200Mi
-            requests:
-              cpu: 10m
-              memory: 20Mi
+          {{- toYaml .Values.operator.kubeRbacProxy.resources | nindent 10 }}
         {{- if .Values.securityContext.kuberbacproxy }}
         securityContext:
         {{- toYaml .Values.securityContext.kuberbacproxy | nindent 10 }}

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -32,6 +32,17 @@ operator:
   # -- Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/))
   affinity: {}
 
+  kubeRbacProxy:
+    resources:
+      # -- The CPU/memory resource limit for the operator component's kube rbac proxy
+      limits:
+        cpu: 300m
+        memory: 200Mi
+      # -- The CPU/memory resource request for the operator component's kube rbac proxy
+      requests:
+        cpu: 10m
+        memory: 20Mi
+
 scaler:
   # -- The image pull secrets for the scaler component
   imagePullSecrets: []


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

The http-add-on helm chart has been updated so the `operator` component's deployment uses the `resources` specified in the helm chart values, and allows them to be overwritten.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- ~README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)~
- ~A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*~

Fixes #
https://github.com/kedacore/charts/issues/565