### PR TITLE
Fix http-add-on verbosity configuration

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -95,7 +95,10 @@ their default values.
 | `logging.interceptor.format` | string | `"console"` | Logging format for KEDA http-add-on Interceptor. allowed values: `json` or `console` |
 | `logging.interceptor.level` | string | `"info"` | Logging level for KEDA http-add-on Interceptor. allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string |
 | `logging.interceptor.timeEncoding` | string | `"rfc3339"` | Logging time encoding for KEDA http-add-on Interceptor. allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano` |
-| `logging.operator.level` | int | `0` | Logging level for Metrics Server. allowed values: `0` for info, `4` for debug, or an integer value greater than 0 |
+| `logging.operator.format` | string | `"console"` | Logging format for KEDA http-add-on operator. allowed values: `json` or `console` |
+| `logging.operator.kubeRbacProxy.level` | int | `10` | Logging level for KEDA http-add-on operator rbac proxy allowed values: `0` for info, `4` for debug, or an integer value greater than 0 |
+| `logging.operator.level` | string | `"info"` | Logging level for KEDA http-add-on operator. allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string |
+| `logging.operator.timeEncoding` | string | `"rfc3339"` | Logging time encoding for KEDA http-add-on operator. allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano` |
 | `logging.scaler.format` | string | `"console"` | Logging format for KEDA http-add-on Scaler. allowed values: `json` or `console` |
 | `logging.scaler.level` | string | `"info"` | Logging level for KEDA http-add-on Scaler. allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string |
 | `logging.scaler.timeEncoding` | string | `"rfc3339"` | Logging time encoding for KEDA http-add-on Scaler. allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano` |

--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -92,6 +92,13 @@ their default values.
 | `images.operator` | string | `"ghcr.io/kedacore/http-add-on-operator"` | Image name for the operator image component |
 | `images.scaler` | string | `"ghcr.io/kedacore/http-add-on-scaler"` | Image name for the scaler image component |
 | `images.tag` | string | `""` | Image tag for the http add on. This tag is applied to the images listed in `images.operator`, `images.interceptor`, and `images.scaler`. Optional, given app version of Helm chart is used by default |
+| `logging.interceptor.format` | string | `"console"` | Logging format for KEDA http-add-on Interceptor. allowed values: `json` or `console` |
+| `logging.interceptor.level` | string | `"info"` | Logging level for KEDA http-add-on Interceptor. allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string |
+| `logging.interceptor.timeEncoding` | string | `"rfc3339"` | Logging time encoding for KEDA http-add-on Interceptor. allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano` |
+| `logging.operator.level` | int | `0` | Logging level for Metrics Server. allowed values: `0` for info, `4` for debug, or an integer value greater than 0 |
+| `logging.scaler.format` | string | `"console"` | Logging format for KEDA http-add-on Scaler. allowed values: `json` or `console` |
+| `logging.scaler.level` | string | `"info"` | Logging level for KEDA http-add-on Scaler. allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string |
+| `logging.scaler.timeEncoding` | string | `"rfc3339"` | Logging time encoding for KEDA http-add-on Scaler. allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano` |
 | `podSecurityContext` | object | [See below](#KEDA-is-secure-by-default) | [Pod security context] for all pods |
 | `rbac.aggregateToDefaultRoles` | bool | `false` | Install aggregate roles for edit and view |
 | `securityContext` | object | [See below](#KEDA-is-secure-by-default) | [Security context] for all containers |

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       {{- end }}
       containers:
       - args:
+          - "--zap-log-level={{ .Values.logging.interceptor.level }}"
+          - "--zap-encoder={{ .Values.logging.interceptor.format }}"
+          - "--zap-time-encoding={{ .Values.logging.interceptor.timeEncoding }}"
         image: "{{ .Values.images.interceptor }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         imagePullPolicy: '{{ .Values.interceptor.pullPolicy | default "Always" }}'
         name: "{{ .Chart.Name }}-interceptor"

--- a/http-add-on/templates/operator/deployment.yaml
+++ b/http-add-on/templates/operator/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - --secure-listen-address=0.0.0.0:{{ .Values.operator.port | default 8443 }}
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
-        - --v={{ .Values.logging.operator.level }}
+        - --v={{ .Values.logging.operator.kubeRbacProxy.level }}
         image: "{{ .Values.images.kubeRbacProxy.name }}:{{ .Values.images.kubeRbacProxy.tag }}"
         name: kube-rbac-proxy
         resources:
@@ -53,6 +53,9 @@ spec:
       - args:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
+        - --zap-log-level={{ .Values.logging.operator.level }}
+        - --zap-time-encoding={{ .Values.logging.operator.timeEncoding }}
+        - --zap-encoder={{ .Values.logging.operator.format }}
         image: "{{ .Values.images.operator }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         imagePullPolicy: '{{ .Values.operator.pullPolicy | default "Always" }}'
         name: "{{ .Chart.Name }}-operator"

--- a/http-add-on/templates/operator/deployment.yaml
+++ b/http-add-on/templates/operator/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - --secure-listen-address=0.0.0.0:{{ .Values.operator.port | default 8443 }}
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
-        - --v=10
+        - --v={{ .Values.logging.operator.level }}
         image: "{{ .Values.images.kubeRbacProxy.name }}:{{ .Values.images.kubeRbacProxy.tag }}"
         name: kube-rbac-proxy
         resources:

--- a/http-add-on/templates/scaler/deployment.yaml
+++ b/http-add-on/templates/scaler/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       {{- end }}
       containers:
       - args:
+          - "--zap-log-level={{ .Values.logging.scaler.level }}"
+          - "--zap-encoder={{ .Values.logging.scaler.format }}"
+          - "--zap-time-encoding={{ .Values.logging.scaler.timeEncoding }}"
         image: "{{ .Values.images.scaler }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.scaler.pullPolicy | default "Always" }}
         name: "{{ .Chart.Name }}-external-scaler"

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -7,9 +7,20 @@ crds:
 
 logging:
   operator:
-    # -- Logging level for Metrics Server.
-    # allowed values: `0` for info, `4` for debug, or an integer value greater than 0
-    level: 0
+    # -- Logging level for KEDA http-add-on operator.
+    # allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string
+    level: info
+    # -- Logging format for KEDA http-add-on operator.
+    # allowed values: `json` or `console`
+    format: console
+    # -- Logging time encoding for KEDA http-add-on operator.
+    # allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano`
+    timeEncoding: rfc3339
+
+    kubeRbacProxy:
+      # -- Logging level for KEDA http-add-on operator rbac proxy
+      # allowed values: `0` for info, `4` for debug, or an integer value greater than 0
+      level: 10
   scaler:
     # -- Logging level for KEDA http-add-on Scaler.
     # allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -5,6 +5,32 @@ crds:
   # -- Whether to install the `HTTPScaledObject` [`CustomResourceDefinition`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
   install: true
 
+logging:
+  operator:
+    # -- Logging level for Metrics Server.
+    # allowed values: `0` for info, `4` for debug, or an integer value greater than 0
+    level: 0
+  scaler:
+    # -- Logging level for KEDA http-add-on Scaler.
+    # allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string
+    level: info
+    # -- Logging format for KEDA http-add-on Scaler.
+    # allowed values: `json` or `console`
+    format: console
+    # -- Logging time encoding for KEDA http-add-on Scaler.
+    # allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano`
+    timeEncoding: rfc3339
+  interceptor:
+    # -- Logging level for KEDA http-add-on Interceptor.
+    # allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string
+    level: info
+    # -- Logging format for KEDA http-add-on Interceptor.
+    # allowed values: `json` or `console`
+    format: console
+    # -- Logging time encoding for KEDA http-add-on Interceptor.
+    # allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano`
+    timeEncoding: rfc3339
+
 # operator-specific configuration values
 operator:
   # -- The image pull secrets for the operator component


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

`http-add-on`:
- Added logging related configuration arguments to deployments and values file
- Updated README with `helm-docs`

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- ~A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*~

Fixes #
https://github.com/kedacore/charts/issues/566
