### PR TITLE
Vault: Allow TriggerAuthentication Defaults via ENV variables

### DIFF
--- a/keda/templates/crds/crd-clustertriggerauthentications.yaml
+++ b/keda/templates/crds/crd-clustertriggerauthentications.yaml
@@ -222,8 +222,6 @@ spec:
                       type: object
                     type: array
                 required:
-                - address
-                - authentication
                 - secrets
                 type: object
               podIdentity:

--- a/keda/templates/crds/crd-triggerauthentications.yaml
+++ b/keda/templates/crds/crd-triggerauthentications.yaml
@@ -221,8 +221,6 @@ spec:
                       type: object
                     type: array
                 required:
-                - address
-                - authentication
                 - secrets
                 type: object
               podIdentity:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

This PR https://github.com/kedacore/keda/pull/5196 allows setting vault values via ENV variables. So we can make them optional in the CRD itself. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes # https://github.com/kedacore/keda/issues/4965
