### PR TITLE
docs: Clarify that contributors do not have to ship Helm chart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thanks for helping making KEDA better!
 
 ## Shipping a new version
 
+> ⚠️ New Helm chart versions are only released in conjunction with KEDA Core or hotfixes, individual PRs do not have to perform these steps
+
 You can easily release a new Helm chart version:
 
 1. Update the version of the Helm chart in [Chart.yaml](keda/Chart.yaml).


### PR DESCRIPTION
Clarify that contributors do not have to ship Helm chart which comes up a lot.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
