### PR TITLE
fix: restore http-add-on chart 0.6.0 indexing

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -3,7 +3,7 @@ entries:
   external-scaler-azure-cosmos-db:
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2023-11-27T18:55:31.362105+01:00"
+    created: "2023-11-30T09:12:28.68395+01:00"
     description: Event-based autoscaler for Azure Cosmos DB change feed consumer applications
     digest: a905dedb01db68575cf591eb0b8f6fa1aa1343f0ec239615081e4b57590d8ae9
     home: https://github.com/kedacore/external-scaler-azure-cosmos-db
@@ -24,7 +24,7 @@ entries:
   keda:
   - apiVersion: v2
     appVersion: 2.12.1
-    created: "2023-11-27T18:55:31.435627+01:00"
+    created: "2023-11-30T09:12:28.740582+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: ee87da063be94f3f65661656602775c38ab723374c9892ecc73c1cea269e64c0
     home: https://github.com/kedacore/keda
@@ -47,7 +47,7 @@ entries:
     version: 2.12.1
   - apiVersion: v2
     appVersion: 2.12.0
-    created: "2023-11-27T18:55:31.432758+01:00"
+    created: "2023-11-30T09:12:28.737913+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 5ae5ef24c2e4c38450bb31b7987aea8b19a828c0c6cfa66b8e7ffbc65ebf164d
     home: https://github.com/kedacore/keda
@@ -70,7 +70,7 @@ entries:
     version: 2.12.0
   - apiVersion: v2
     appVersion: 2.11.2
-    created: "2023-11-27T18:55:31.428389+01:00"
+    created: "2023-11-30T09:12:28.735381+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 1fc274ebf7c405031297166fa3295f13bc9470f3ca688d595b7549d072b062cd
     home: https://github.com/kedacore/keda
@@ -93,7 +93,7 @@ entries:
     version: 2.11.2
   - apiVersion: v2
     appVersion: 2.11.1
-    created: "2023-11-27T18:55:31.425693+01:00"
+    created: "2023-11-30T09:12:28.732731+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 7d10ab788d363c95f496f28d48a74ab7789a5d04c63d9fa3e5d55967c988c0ed
     home: https://github.com/kedacore/keda
@@ -116,7 +116,7 @@ entries:
     version: 2.11.1
   - apiVersion: v2
     appVersion: 2.11.0
-    created: "2023-11-27T18:55:31.421954+01:00"
+    created: "2023-11-30T09:12:28.730667+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 8a2100ac1c47053e118b177676fbc07fe427fb9878c31ee7f8b73df0e2a77a06
     home: https://github.com/kedacore/keda
@@ -139,7 +139,7 @@ entries:
     version: 2.11.0
   - apiVersion: v2
     appVersion: 2.10.1
-    created: "2023-11-27T18:55:31.418432+01:00"
+    created: "2023-11-30T09:12:28.728117+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 2e75903cda0780a4a8115dc199541315eaccdbfc3ec3da5ab492c8825080cc99
     home: https://github.com/kedacore/keda
@@ -162,7 +162,7 @@ entries:
     version: 2.10.2
   - apiVersion: v2
     appVersion: 2.10.0
-    created: "2023-11-27T18:55:31.416006+01:00"
+    created: "2023-11-30T09:12:28.726019+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 7216ff7cff5567152b895017b97a95b41b788589c4be82169d92906519a24f25
     home: https://github.com/kedacore/keda
@@ -185,7 +185,7 @@ entries:
     version: 2.10.1
   - apiVersion: v2
     appVersion: 2.10.0
-    created: "2023-11-27T18:55:31.41325+01:00"
+    created: "2023-11-30T09:12:28.72344+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 4be1fc8dba9d0e17ff475ca3dcb1183b07164ccaddfc48c67f6369a56f1b1777
     home: https://github.com/kedacore/keda
@@ -208,7 +208,7 @@ entries:
     version: 2.10.0
   - apiVersion: v2
     appVersion: 2.9.3
-    created: "2023-11-27T18:55:31.484734+01:00"
+    created: "2023-11-30T09:12:28.780031+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: c455dc8d908b6e8575fe0dbe8275861355cb242a5768f23cd909e543fe077438
     home: https://github.com/kedacore/keda
@@ -231,7 +231,7 @@ entries:
     version: 2.9.4
   - apiVersion: v2
     appVersion: 2.9.2
-    created: "2023-11-27T18:55:31.482114+01:00"
+    created: "2023-11-30T09:12:28.777909+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 52a5de6f5585fb2cfe44ba9ddadcf4cd4208138795313e25ee654d82a424faef
     home: https://github.com/kedacore/keda
@@ -254,7 +254,7 @@ entries:
     version: 2.9.3
   - apiVersion: v2
     appVersion: 2.9.2
-    created: "2023-11-27T18:55:31.479982+01:00"
+    created: "2023-11-30T09:12:28.776116+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: a1f14048f1788cde92a42412fa789e34d48bb4a8e94d4b43e0c70c8b8c326e43
     home: https://github.com/kedacore/keda
@@ -277,7 +277,7 @@ entries:
     version: 2.9.2
   - apiVersion: v2
     appVersion: 2.9.1
-    created: "2023-11-27T18:55:31.477193+01:00"
+    created: "2023-11-30T09:12:28.773922+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 004f2f37845a324badc7228585755ddfd8f5feea957cdca7de9b39499ce1a8d8
     home: https://github.com/kedacore/keda
@@ -300,7 +300,7 @@ entries:
     version: 2.9.1
   - apiVersion: v2
     appVersion: 2.9.0
-    created: "2023-11-27T18:55:31.475097+01:00"
+    created: "2023-11-30T09:12:28.772046+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: e0f84de35c0378027f43a732f12a164db05e45947687203020c0031baeee5826
     home: https://github.com/kedacore/keda
@@ -323,7 +323,7 @@ entries:
     version: 2.9.0
   - apiVersion: v2
     appVersion: 2.8.2
-    created: "2023-11-27T18:55:31.472275+01:00"
+    created: "2023-11-30T09:12:28.769801+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: bbd9f4f9312781de5363145d5a937d7c084ea1139f12f5e7f153b3f174332517
     home: https://github.com/kedacore/keda
@@ -346,7 +346,7 @@ entries:
     version: 2.8.4
   - apiVersion: v2
     appVersion: 2.8.2
-    created: "2023-11-27T18:55:31.47028+01:00"
+    created: "2023-11-30T09:12:28.76788+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 04934ca1e41970ca687de13db697cc7fdc24d367af570eba47bed01ad981e1b1
     home: https://github.com/kedacore/keda
@@ -369,7 +369,7 @@ entries:
     version: 2.8.3
   - apiVersion: v2
     appVersion: 2.8.1
-    created: "2023-11-27T18:55:31.467552+01:00"
+    created: "2023-11-30T09:12:28.766195+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: e7bc80a5dde861a5f62b73e9d5c4ce139339b07438344668485fdc435f3109b4
     home: https://github.com/kedacore/keda
@@ -392,7 +392,7 @@ entries:
     version: 2.8.2
   - apiVersion: v2
     appVersion: 2.8.0
-    created: "2023-11-27T18:55:31.465502+01:00"
+    created: "2023-11-30T09:12:28.764164+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: df15ce1a4a27df2f3eb85c7cc803de53dec526bcad92d732a0944bd5288f4845
     home: https://github.com/kedacore/keda
@@ -415,7 +415,7 @@ entries:
     version: 2.8.1
   - apiVersion: v2
     appVersion: 2.8.0
-    created: "2023-11-27T18:55:31.462843+01:00"
+    created: "2023-11-30T09:12:28.762407+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: afa9410e4e6e805979e5c22a17db6dc7dc2720c28b3f176d2eef2708ef0d0a32
     home: https://github.com/kedacore/keda
@@ -438,7 +438,7 @@ entries:
     version: 2.8.0
   - apiVersion: v2
     appVersion: 2.7.1
-    created: "2023-11-27T18:55:31.461145+01:00"
+    created: "2023-11-30T09:12:28.760718+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: eec27b3d7075a8c51cce1fb8d456ac3d458b3bf72fde1cda67c4b554df1e9838
     home: https://github.com/kedacore/keda
@@ -461,7 +461,7 @@ entries:
     version: 2.7.2
   - apiVersion: v2
     appVersion: 2.7.1
-    created: "2023-11-27T18:55:31.459474+01:00"
+    created: "2023-11-30T09:12:28.759253+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: aa1644eb53ec44294993d0611169bd863db39f2bedca1d9ed64b05fbef74087c
     home: https://github.com/kedacore/keda
@@ -484,7 +484,7 @@ entries:
     version: 2.7.1
   - apiVersion: v2
     appVersion: 2.7.0
-    created: "2023-11-27T18:55:31.457015+01:00"
+    created: "2023-11-30T09:12:28.757871+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: f23894c1c4403f36797a0f2ccb497a3b4f2fe761e00b841cc7e1c8ce110d6dc5
     home: https://github.com/kedacore/keda
@@ -507,7 +507,7 @@ entries:
     version: 2.7.0
   - apiVersion: v2
     appVersion: 2.6.1
-    created: "2023-11-27T18:55:31.455305+01:00"
+    created: "2023-11-30T09:12:28.75646+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: af7ec480a66e9f033ab44d28b3df518c0def8ea289996c413dae34e307a0a033
     home: https://github.com/kedacore/keda
@@ -529,7 +529,7 @@ entries:
     version: 2.6.2
   - apiVersion: v2
     appVersion: 2.6.0
-    created: "2023-11-27T18:55:31.453242+01:00"
+    created: "2023-11-30T09:12:28.754845+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: b6cf54875f34e8cda992f1ccfe7d594a2f75d25b573a8149721e69ab5ebe3d1d
     home: https://github.com/kedacore/keda
@@ -551,7 +551,7 @@ entries:
     version: 2.6.1
   - apiVersion: v2
     appVersion: 2.6.0
-    created: "2023-11-27T18:55:31.451586+01:00"
+    created: "2023-11-30T09:12:28.753487+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 1788eb5f7febdff68275ec5446d30f7f51d0259f343a024639ab1d46228fa00c
     home: https://github.com/kedacore/keda
@@ -573,7 +573,7 @@ entries:
     version: 2.6.0
   - apiVersion: v2
     appVersion: 2.5.0
-    created: "2023-11-27T18:55:31.449989+01:00"
+    created: "2023-11-30T09:12:28.752152+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: b23ffc14ff517dbf1e892593364a0b9e660afe2cd49c2e11e8589e0f271ef254
     home: https://github.com/kedacore/keda
@@ -595,7 +595,7 @@ entries:
     version: 2.5.1
   - apiVersion: v2
     appVersion: 2.5.0
-    created: "2023-11-27T18:55:31.447944+01:00"
+    created: "2023-11-30T09:12:28.750645+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: a8c62e7b9e38adf3ef1837e2828cbd29dfd6c7633e8260bd2aa68c70307c8149
     home: https://github.com/kedacore/keda
@@ -615,7 +615,7 @@ entries:
     version: 2.5.0
   - apiVersion: v2
     appVersion: 2.4.0
-    created: "2023-11-27T18:55:31.446375+01:00"
+    created: "2023-11-30T09:12:28.749292+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 41a092fcda3518068d27cf7b86afa5ea2577c8435055ee214bfba11f3a86ef7b
     home: https://github.com/kedacore/keda
@@ -635,7 +635,7 @@ entries:
     version: 2.4.0
   - apiVersion: v2
     appVersion: 2.3.0
-    created: "2023-11-27T18:55:31.444706+01:00"
+    created: "2023-11-30T09:12:28.747851+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 8f9d78fb5d090e9887f7914ec8db637344361a8881bb4d8f4c1a9225964b72e0
     home: https://github.com/kedacore/keda
@@ -655,7 +655,7 @@ entries:
     version: 2.3.2
   - apiVersion: v2
     appVersion: 2.3.0
-    created: "2023-11-27T18:55:31.442677+01:00"
+    created: "2023-11-30T09:12:28.74645+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: c36eef4718068eee2ac8d3d54e10b15c6ca2b4d1970c84797387152393804578
     home: https://github.com/kedacore/keda
@@ -675,7 +675,7 @@ entries:
     version: 2.3.0
   - apiVersion: v2
     appVersion: 2.2.0
-    created: "2023-11-27T18:55:31.441043+01:00"
+    created: "2023-11-30T09:12:28.744667+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 6b6b25799c11e01d2a7edb34d8cf3fb6f82393e7c4e9faa07c38271afad49704
     home: https://github.com/kedacore/keda
@@ -695,7 +695,7 @@ entries:
     version: 2.2.2
   - apiVersion: v2
     appVersion: 2.2.0
-    created: "2023-11-27T18:55:31.439377+01:00"
+    created: "2023-11-30T09:12:28.74329+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 7ec5c403d0ad315d2eb9ec0c9d73b36c0baced870f397884d467d46014f24631
     home: https://github.com/kedacore/keda
@@ -715,7 +715,7 @@ entries:
     version: 2.2.1
   - apiVersion: v2
     appVersion: 2.2.0
-    created: "2023-11-27T18:55:31.437212+01:00"
+    created: "2023-11-30T09:12:28.741928+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 42b530656687cabb1408abcb137a5d7515243465b65a3a6006927987441fadc0
     home: https://github.com/kedacore/keda
@@ -735,7 +735,7 @@ entries:
     version: 2.2.0
   - apiVersion: v2
     appVersion: 2.1.0
-    created: "2023-11-27T18:55:31.410783+01:00"
+    created: "2023-11-30T09:12:28.721051+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 65e2fb98c55740251d7ffa1680ef0edeb42954576deac3856dd468473e321747
     home: https://github.com/kedacore/keda
@@ -755,7 +755,7 @@ entries:
     version: 2.1.3
   - apiVersion: v2
     appVersion: 2.1.0
-    created: "2023-11-27T18:55:31.408763+01:00"
+    created: "2023-11-30T09:12:28.719494+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: f336ab24d5ebf96d28da95a03931f2701bb44ce6bb7c30991e3ad14959e2e7e4
     home: https://github.com/kedacore/keda
@@ -775,7 +775,7 @@ entries:
     version: 2.1.2
   - apiVersion: v2
     appVersion: 2.1.0
-    created: "2023-11-27T18:55:31.406993+01:00"
+    created: "2023-11-30T09:12:28.718177+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: b6e752d05797cd50ce95a96ae1b6cf8b2b87fc10c27391172beb1acd9fcb18a2
     home: https://github.com/kedacore/keda
@@ -795,7 +795,7 @@ entries:
     version: 2.1.1
   - apiVersion: v2
     appVersion: 2.1.0
-    created: "2023-11-27T18:55:31.405409+01:00"
+    created: "2023-11-30T09:12:28.716879+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 91998f9165176f972b954ef9d4077942979cb5e863bb7d76ed29c48f63533531
     home: https://github.com/kedacore/keda
@@ -815,7 +815,7 @@ entries:
     version: 2.1.0
   - apiVersion: v2
     appVersion: 2.0.0
-    created: "2023-11-27T18:55:31.403448+01:00"
+    created: "2023-11-30T09:12:28.715224+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: ce2e848f5d7a067d74feb3745da5a834cccdfaa665b5b59d43ad06baa4cdfd04
     home: https://github.com/kedacore/keda
@@ -835,7 +835,7 @@ entries:
     version: 2.0.1
   - apiVersion: v1
     appVersion: 2.0.0
-    created: "2023-11-27T18:55:31.401956+01:00"
+    created: "2023-11-30T09:12:28.71398+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: dba8b0e793085165c7d155f9393c5ff112d4714dbce0201404ceb0e67d1b2deb
     home: https://github.com/kedacore/keda
@@ -855,7 +855,7 @@ entries:
     version: 2.0.0
   - apiVersion: v1
     appVersion: 2.0.0-rc2
-    created: "2023-11-27T18:55:31.400458+01:00"
+    created: "2023-11-30T09:12:28.712737+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: bad82c28c5ca1d5e69fac4bfcc7a999d5d2b2afd9b19ff6deb9a48811110eb0d
     home: https://github.com/kedacore/keda
@@ -875,7 +875,7 @@ entries:
     version: 2.0.0-rc3
   - apiVersion: v2
     appVersion: 2.0.0-rc2
-    created: "2023-11-27T18:55:31.398925+01:00"
+    created: "2023-11-30T09:12:28.711127+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: a4042ba14e595a8e82c9a39d8987625b89292aa86029686a3603b724fda36ca0
     home: https://github.com/kedacore/keda
@@ -896,7 +896,7 @@ entries:
     version: 2.0.0-rc2
   - apiVersion: v1
     appVersion: 2.0.0-rc
-    created: "2023-11-27T18:55:31.395932+01:00"
+    created: "2023-11-30T09:12:28.70989+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 3a952f2aaa0ea35ee4335f0b168f44fcf37c5c5ab7e9b9bba7e731c42f04ad61
     home: https://github.com/kedacore/keda
@@ -916,7 +916,7 @@ entries:
     version: 2.0.0-rc
   - apiVersion: v1
     appVersion: 2.0.0-beta
-    created: "2023-11-27T18:55:31.394349+01:00"
+    created: "2023-11-30T09:12:28.708648+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: fbafc7ae564c13a0eab7062667759f6e93595c97125731a27e8290574e1d570c
     home: https://github.com/kedacore/keda
@@ -936,7 +936,7 @@ entries:
     version: 2.0.0-beta1.2
   - apiVersion: v1
     appVersion: 2.0.0-beta
-    created: "2023-11-27T18:55:31.39181+01:00"
+    created: "2023-11-30T09:12:28.706212+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: db9e7d2423423463285f2e9d5b940a63b41d6555ba9fcab8fda0e6a757ccefa9
     home: https://github.com/kedacore/keda
@@ -956,7 +956,7 @@ entries:
     version: 2.0.0-beta1.1
   - apiVersion: v1
     appVersion: 2.0.0-beta
-    created: "2023-11-27T18:55:31.388934+01:00"
+    created: "2023-11-30T09:12:28.704072+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: f0a8f0b854246ee2258ec8f10528f2811681ad2e41946dc455586f1ba9818e01
     home: https://github.com/kedacore/keda
@@ -976,7 +976,7 @@ entries:
     version: 2.0.0-beta
   - apiVersion: v1
     appVersion: 1.5.0
-    created: "2023-11-27T18:55:31.386435+01:00"
+    created: "2023-11-30T09:12:28.701927+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 07b15ddae4f1c40747de063100a668ac15d504cd0548eac0e1a04381fcaa3b37
     home: https://github.com/kedacore/keda
@@ -996,7 +996,7 @@ entries:
     version: 1.5.0
   - apiVersion: v1
     appVersion: 1.4.1
-    created: "2023-11-27T18:55:31.38451+01:00"
+    created: "2023-11-30T09:12:28.700049+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: f8bf80186ac3343998021a1721d06a67fdacd1dab92e4a4992620903b52004a4
     home: https://github.com/kedacore/keda
@@ -1016,7 +1016,7 @@ entries:
     version: 1.4.2
   - apiVersion: v1
     appVersion: 1.4.1
-    created: "2023-11-27T18:55:31.38222+01:00"
+    created: "2023-11-30T09:12:28.698225+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 97a2e5c0beff93bb71ff861da0f29d09dcf988e724784f8b7c56ac9872c37a81
     home: https://github.com/kedacore/keda
@@ -1032,7 +1032,7 @@ entries:
     version: 1.4.1
   - apiVersion: v1
     appVersion: 1.4.0
-    created: "2023-11-27T18:55:31.380315+01:00"
+    created: "2023-11-30T09:12:28.696224+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 1c4dbc502b935898ecaa178b5f0a172be5d75302c729dd96224a19f0dfe7964f
     home: https://github.com/kedacore/keda
@@ -1048,7 +1048,7 @@ entries:
     version: 1.4.0
   - apiVersion: v1
     appVersion: 1.4.0
-    created: "2023-11-27T18:55:31.377464+01:00"
+    created: "2023-11-30T09:12:28.694751+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: 6fccc45972ba1e3e9b2a6d3a20d4c6da4e8e1707e28cbf9f52114811628e7498
     home: https://github.com/kedacore/keda
@@ -1064,7 +1064,7 @@ entries:
     version: 1.3.2
   - apiVersion: v1
     appVersion: 1.3.0
-    created: "2023-11-27T18:55:31.375538+01:00"
+    created: "2023-11-30T09:12:28.692953+01:00"
     description: Event-based autoscaler for workloads on Kubernetes
     digest: e13bcb65816ed59b10b32fa6db8f61668635459d56c2d599bb3c0bcc5dcc1368
     home: https://github.com/kedacore/keda
@@ -1080,7 +1080,7 @@ entries:
     version: 1.3.1
   - apiVersion: v1
     appVersion: 1.3.0
-    created: "2023-11-27T18:55:31.371971+01:00"
+    created: "2023-11-30T09:12:28.691479+01:00"
     description: Event based autoscaler for Azure Functions deployments on Kubernetes
     digest: 28fed67bbc6ee61357743991f6c66a88b3749d9d7e9d26322f4f9116d038acb8
     home: https://github.com/kedacore/keda
@@ -1096,7 +1096,7 @@ entries:
     version: 1.3.0
   - apiVersion: v1
     appVersion: 1.2.0
-    created: "2023-11-27T18:55:31.369804+01:00"
+    created: "2023-11-30T09:12:28.689924+01:00"
     description: Event based autoscaler for Azure Functions deployments on Kubernetes
     digest: e041dbed2455fef34f2908594a42fc8a7f163a1f48be46c2f93dea46e36fc733
     home: https://github.com/kedacore/keda
@@ -1112,7 +1112,7 @@ entries:
     version: 1.2.0
   - apiVersion: v1
     appVersion: 1.1.0
-    created: "2023-11-27T18:55:31.367829+01:00"
+    created: "2023-11-30T09:12:28.687836+01:00"
     description: Event based autoscaler for Azure Functions deployments on Kubernetes
     digest: c624e6620a9a6f265f51a82ee0d8267dcb2637dd3777306afbb271746234ff2d
     home: https://github.com/kedacore/keda
@@ -1128,7 +1128,7 @@ entries:
     version: 1.1.0
   - apiVersion: v1
     appVersion: 1.0.0
-    created: "2023-11-27T18:55:31.364383+01:00"
+    created: "2023-11-30T09:12:28.685969+01:00"
     description: Event based autoscaler for Azure Functions deployments on Kubernetes
     digest: ef934588dce70d874ea69692e082b8a70ad19095090b8d4fa7b5cb69b2cecaf6
     home: https://github.com/kedacore/keda
@@ -1144,8 +1144,31 @@ entries:
     version: 1.0.0
   keda-add-ons-http:
   - apiVersion: v2
+    appVersion: 0.6.0
+    created: "2023-11-30T09:12:28.785859+01:00"
+    description: Event-based autoscaler for HTTP workloads on Kubernetes
+    digest: 435c6c9c221b8e98774c662250a091b872222584510e3b7f1df2a838afa81252
+    home: https://github.com/kedacore/http-add-on
+    kubeVersion: '>=v1.23.0-0'
+    maintainers:
+    - email: ahmels@microsoft.com
+      name: Ahmed ElSayed
+    - email: jorge_turrado@hotmail.es
+      name: Jorge Turrado
+    - email: kerkhove.tom@gmail.com
+      name: Tom Kerkhove
+    - email: zbynek@kedify.io
+      name: Zbynek Roubalik
+    name: keda-add-ons-http
+    sources:
+    - https://github.com/kedacore/http-add-on
+    type: application
+    urls:
+    - https://kedacore.github.io/charts/keda-add-ons-http-0.6.0.tgz
+    version: 0.6.0
+  - apiVersion: v2
     appVersion: 0.5.0
-    created: "2023-11-27T18:55:31.490795+01:00"
+    created: "2023-11-30T09:12:28.785385+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: 2f7a41ea8fbed944ea789e5811edcb263275452d6c8928a4647d78d0d9895b15
     home: https://github.com/kedacore/http-add-on
@@ -1168,7 +1191,7 @@ entries:
     version: 0.5.3
   - apiVersion: v2
     appVersion: 0.5.0
-    created: "2023-11-27T18:55:31.490238+01:00"
+    created: "2023-11-30T09:12:28.784908+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: cc4459e84407bc2b29203ad02ddcea31471ce3b3d1c4a91c0d7f6be212725c38
     home: https://github.com/kedacore/http-add-on
@@ -1191,7 +1214,7 @@ entries:
     version: 0.5.2
   - apiVersion: v2
     appVersion: 0.5.0
-    created: "2023-11-27T18:55:31.489696+01:00"
+    created: "2023-11-30T09:12:28.784438+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: 802dd7fa808a092b1c3669e217b6295c600929351fd7ad9ff6485b5ffa7ac87d
     home: https://github.com/kedacore/http-add-on
@@ -1214,7 +1237,7 @@ entries:
     version: 0.5.1
   - apiVersion: v2
     appVersion: 0.5.0
-    created: "2023-11-27T18:55:31.489147+01:00"
+    created: "2023-11-30T09:12:28.783948+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: 436f37e50c6a2cb406b13144778163070b3903a77750ac2afd71a13c07edd7d3
     home: https://github.com/kedacore/http-add-on
@@ -1237,7 +1260,7 @@ entries:
     version: 0.5.0
   - apiVersion: v2
     appVersion: 0.4.0
-    created: "2023-11-27T18:55:31.488603+01:00"
+    created: "2023-11-30T09:12:28.783451+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: ed7e2d31de0f5afff393e1c8857968b68777ff2e29678351ae6e85dfeb54e2f1
     home: https://github.com/kedacore/http-add-on
@@ -1260,7 +1283,7 @@ entries:
     version: 0.4.1
   - apiVersion: v2
     appVersion: 0.4.0
-    created: "2023-11-27T18:55:31.488117+01:00"
+    created: "2023-11-30T09:12:28.783023+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: 63a58740d9a528b16cff62eb78ab7c33ac1bb00c1f5d4802cd3de1229f24b1c8
     home: https://github.com/kedacore/http-add-on
@@ -1283,7 +1306,7 @@ entries:
     version: 0.4.0
   - apiVersion: v2
     appVersion: 0.3.0
-    created: "2023-11-27T18:55:31.48766+01:00"
+    created: "2023-11-30T09:12:28.78261+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: 79ace4c4fa1521f9e072c34917155db49047b024f77054df2a089aca9a686b14
     home: https://github.com/kedacore/http-add-on
@@ -1308,7 +1331,7 @@ entries:
     version: 0.3.1
   - apiVersion: v2
     appVersion: 0.3.0
-    created: "2023-11-27T18:55:31.487182+01:00"
+    created: "2023-11-30T09:12:28.78218+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: e48c9139df0d83cea4b1faed0094d87707243dbfe620eab2254c7d810ed0f4c2
     home: https://github.com/kedacore/http-add-on
@@ -1332,7 +1355,7 @@ entries:
     version: 0.3.0
   - apiVersion: v2
     appVersion: 0.2.0
-    created: "2023-11-27T18:55:31.486703+01:00"
+    created: "2023-11-30T09:12:28.781764+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: ba2bc1bc4445a0aca8e71726f5e0797941a67f5d98764c56be300f6b2c5c008b
     home: https://github.com/kedacore/http-add-on
@@ -1356,7 +1379,7 @@ entries:
     version: 0.2.2
   - apiVersion: v2
     appVersion: 0.2.0
-    created: "2023-11-27T18:55:31.486234+01:00"
+    created: "2023-11-30T09:12:28.781339+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: 0dc118417aad98e528e499fdd5e4e8a43465d071dd954612ff5d0289756d372c
     home: https://github.com/kedacore/http-add-on
@@ -1380,7 +1403,7 @@ entries:
     version: 0.2.1
   - apiVersion: v2
     appVersion: 0.2.0
-    created: "2023-11-27T18:55:31.485733+01:00"
+    created: "2023-11-30T09:12:28.780926+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: 2c209e2a1287a54934cd7e1345fddc5b2b6c2a51c92d07a314f3e08e304af321
     home: https://github.com/kedacore/http-add-on
@@ -1404,7 +1427,7 @@ entries:
     version: 0.2.0
   - apiVersion: v2
     appVersion: 0.1.0
-    created: "2023-11-27T18:55:31.485294+01:00"
+    created: "2023-11-30T09:12:28.780543+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: 51bc31412a28fe78a0d0b2cdb76aae1af9eda9707ceecdfdde7106b7a2ceb8cb
     home: https://github.com/kedacore/http-add-on
@@ -1428,7 +1451,7 @@ entries:
     version: 0.1.0
   - apiVersion: v2
     appVersion: 0.0.1
-    created: "2023-11-27T18:55:31.485036+01:00"
+    created: "2023-11-30T09:12:28.780303+01:00"
     description: Event-based autoscaler for HTTP workloads on Kubernetes
     digest: 0cbcd436721095d7f40750a917ed22d7c83883bdb256edfd43a40a5a0b4f5c17
     home: https://github.com/kedacore/http-add-on
@@ -1450,4 +1473,4 @@ entries:
     urls:
     - https://kedacore.github.io/charts/keda-add-ons-http-0.0.1.tgz
     version: 0.0.1
-generated: "2023-11-27T18:55:31.359315+01:00"
+generated: "2023-11-30T09:12:28.683656+01:00"

--- a/keda/README.md
+++ b/keda/README.md
@@ -21,7 +21,7 @@ helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
 
 kubectl create namespace keda
-helm install keda kedacore/keda --namespace keda --version 2.12.0
+helm install keda kedacore/keda --namespace keda --version 2.12.1
 ```
 
 ## Introduction
@@ -36,7 +36,7 @@ To install the chart with the release name `keda`:
 
 ```console
 $ kubectl create namespace keda
-$ helm install keda kedacore/keda --namespace keda --version 2.12.0
+$ helm install keda kedacore/keda --namespace keda --version 2.12.1
 ```
 
 ## Uninstalling the Chart
@@ -119,6 +119,7 @@ their default values.
 | `logging.operator.level` | string | `"info"` | Logging level for KEDA Operator. allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string |
 | `logging.operator.timeEncoding` | string | `"rfc3339"` | Logging time encoding for KEDA Operator. allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano` |
 | `operator.affinity` | object | `{}` | [Affinity] for pod scheduling for KEDA operator. Takes precedence over the `affinity` field |
+| `operator.disableCompression` | bool | `true` | Disable response compression for k8s restAPI in client-go.  Disabling compression simply means that turns off the process of making data smaller for K8s restAPI in client-go for faster transmission. |
 | `operator.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":25,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `operator.name` | string | `"keda-operator"` | Name of the KEDA operator |
 | `operator.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":20,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |
@@ -147,6 +148,7 @@ their default values.
 | `logging.metricServer.level` | int | `0` | Logging level for Metrics Server. allowed values: `0` for info, `4` for debug, or an integer value greater than 0, specified as string |
 | `logging.metricServer.stderrthreshold` | string | `"ERROR"` | Logging stderrthreshold for Metrics Server allowed values: 'DEBUG','INFO','WARN','ERROR','ALERT','EMERG' |
 | `metricsServer.affinity` | object | `{}` | [Affinity] for pod scheduling for Metrics API Server. Takes precedence over the `affinity` field |
+| `metricsServer.disableCompression` | bool | `true` | Disable response compression for k8s restAPI in client-go. Disabling compression simply means that turns off the process of making data smaller for K8s restAPI in client-go for faster transmission. |
 | `metricsServer.dnsPolicy` | string | `"ClusterFirst"` | Defined the DNS policy for the metric server |
 | `metricsServer.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `metricsServer.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |


### PR DESCRIPTION
During last release, we removed http add-on 0.6.0 from the index by mistake

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes https://github.com/kedacore/charts/issues/578
