### PR TITLE
fix(add-on): Use `main` tag for KEDA chart on CI

### DIFF
--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -77,8 +77,19 @@ jobs:
       - name: Create KEDA namespace
         run: kubectl create ns keda
 
+      - name: Generate values
+        run: |
+          cat <<EOF > keda-values.yaml
+          image:
+            keda:
+              tag: main
+            metricsApiServer:
+              tag: main
+            webhooks:
+              tag: main
+
       - name: Install KEDA chart
-        run: helm install keda ./keda/ --namespace keda
+        run: helm install keda ./keda/ --namespace keda --values keda-values.yaml
 
       - name: Generate values
         run: |


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
