### PR TITLE
fix(add-on): Use 'main' tag for KEDA installation during CI

### DIFF
--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -77,8 +77,19 @@ jobs:
       - name: Create KEDA namespace
         run: kubectl create ns keda
 
+      - name: Generate values
+        run: |
+          cat <<EOF > keda-values.yaml
+          image:
+            keda:
+              tag: main
+            metricsApiServer:
+              tag: main
+            webhooks:
+              tag: main
+
       - name: Install KEDA chart
-        run: helm install keda ./keda/ --namespace keda
+        run: helm install keda ./keda/ --namespace keda --values keda-values.yaml
 
       - name: Generate values
         run: |


### PR DESCRIPTION
HTTP Add-on CI is broken because we use KEDA chart from the repo, but it has changes not compatible with v2.12 (a new argument), so we have to use main tag too