### PR TITLE
feat(ClusterRole): Add RBAC rule to allow access to `LimitRange`

### DIFF
--- a/keda/templates/manager/clusterrole.yaml
+++ b/keda/templates/manager/clusterrole.yaml
@@ -42,6 +42,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - limitranges
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - list


### PR DESCRIPTION
_Provide a description of what has been changed_

Allow keda-operator to access the LimitRange resources in the cluster. The operator requires this to validate whether the default limits are available on the container in case of using CPU/memory triggers.

This is to sync the chart with changes in https://github.com/kedacore/keda/pull/5377

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*  https://github.com/kedacore/keda/pull/5377

Relates to https://github.com/kedacore/keda/issues/5348
