### PR TITLE
fix: pod monitor port name does not match deployment spec

### DIFF
--- a/keda/templates/manager/podmonitor.yaml
+++ b/keda/templates/manager/podmonitor.yaml
@@ -18,7 +18,7 @@ metadata:
   {{- end }}
 spec:
   podMetricsEndpoints:
-  - port: http
+  - port: metrics
     path: /metrics
     {{- with .Values.prometheus.operator.podMonitor.interval }}
     interval: {{ . }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

PodMonitor port name is set as `http` but the deployment port name is set as `metrics`.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #601
