### PR TITLE
Add hostIP var to operator

### DIFF
--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -145,6 +145,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             - name: OPERATOR_NAME
               value: {{ .Values.operator.name }}
             - name: KEDA_HTTP_DEFAULT_TIMEOUT


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->
Hello!

I'm running DataDog agents as a Daemonset and they are capable of collecting OTEL metrics, however I need the `.Values.opentelemetry.collector.uri` variable to refer to the node's IP address. If I use `.Values.env` to add the hostIP downward api variable it is lower in the env list and thus lower in precedence than `.Values.opentelemetry.collector.uri`. Unfortunately it doesn't get replaced when I set it like this:
```
- name: OTEL_EXPORTER_OTLP_ENDPOINT
  value: http://$(HOST_IP):4318
```

When I put the env var near the top of the list `$(HOST_IP)` gets substituted correctly.

[Relevant DataDog documentation](https://docs.datadoghq.com/opentelemetry/collector_exporter/?tab=kubernetesdaemonset#running-the-collector):

<kbd>![image](https://github.com/kedacore/charts/assets/56136770/eb0a22c2-c8d9-447a-9438-e8082af4b77d)</kbd>

I'm happy to put this behind a value for toggling if that's preferred.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
