### PR TITLE
Added ScaledObject parameter StartReplicaCount to scale from 0 to N

### DIFF
--- a/keda/templates/crds/crd-scaledobjects.yaml
+++ b/keda/templates/crds/crd-scaledobjects.yaml
@@ -35,6 +35,9 @@ spec:
     - jsonPath: .spec.maxReplicaCount
       name: Max
       type: integer
+    - jsonPath: .spec.startReplicaCount
+      name: Start
+      type: integer
     - jsonPath: .spec.triggers[*].type
       name: Triggers
       type: string
@@ -253,6 +256,9 @@ spec:
                 format: int32
                 type: integer
               minReplicaCount:
+                format: int32
+                type: integer
+              startReplicaCount:
                 format: int32
                 type: integer
               pollingInterval:


### PR DESCRIPTION
This pull request introduces a new parameter, startReplicaCount, to the ScaledObject in order to change the scaling behavior from 0. The goal is to facilitate scaling from 0 to N replicas, instead of the default 0 to 1.
This change can be useful in scenarios where applications need fast responsiveness when is activated.

### Checklist

- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Commits are signed with Developer Certificate of Origin 
- [ ] A PR is opened to update KEDA core 