### PR TITLE
Add extra sidecar containers config for Keda operator

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -140,6 +140,22 @@ jobs:
           certManager:
             enabled: ${{ matrix.enableCertManager }}
             generateCA: true
+        extraInitContainers:
+          - name: hello-once
+            args:
+              - -c
+              - "echo 'Hello World!'"
+            command:
+              - /bin/sh
+            image: 'busybox:glibc'
+        extraContainers:
+          - name: hello-many
+            args:
+              - -c
+              - "while true; do echo hi; sleep 300; done"
+            command:
+              - /bin/sh
+            image: 'busybox:glibc'
         extraObjects:
           - apiVersion: keda.sh/v1alpha1
             kind: ClusterTriggerAuthentication

--- a/keda/README.md
+++ b/keda/README.md
@@ -131,6 +131,8 @@ their default values.
 | `logging.operator.timeEncoding` | string | `"rfc3339"` | Logging time encoding for KEDA Operator. allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano` |
 | `operator.affinity` | object | `{}` | [Affinity] for pod scheduling for KEDA operator. Takes precedence over the `affinity` field |
 | `operator.disableCompression` | bool | `true` | Disable response compression for k8s restAPI in client-go. Disabling compression simply means that turns off the process of making data smaller for K8s restAPI in client-go for faster transmission. |
+| `operator.extraContainers` | list | `[]` | Additional containers to run as part of the operator deployment |
+| `operator.extraInitContainers` | list | `[]` | Additional init containers to run as part of the operator deployment |
 | `operator.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":25,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `operator.name` | string | `"keda-operator"` | Name of the KEDA operator |
 | `operator.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":20,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -187,6 +187,13 @@ spec:
             {{- else }}
             {{- toYaml .Values.resources | nindent 12 }}
             {{- end }}
+        {{- if .Values.operator.extraContainers }}
+        {{- toYaml .Values.operator.extraContainers | nindent 8 }}
+        {{- end }}
+      {{- if .Values.operator.extraInitContainers }}
+      initContainers:
+      {{- toYaml .Values.operator.extraInitContainers | nindent 8 }}
+      {{- end }}
       volumes:
       - name: certificates
         secret:

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -87,6 +87,24 @@ operator:
     #         values:
     #         - keda-operator
     #     topologyKey: "kubernetes.io/hostname"
+  # -- Additional containers to run as part of the operator deployment
+  extraContainers: []
+    # - name: hello-many
+    # args:
+    #   - -c
+    #   - "while true; do echo hi; sleep 300; done"
+    # command:
+    #   - /bin/sh
+    # image: 'busybox:glibc'
+  # -- Additional init containers to run as part of the operator deployment
+  extraInitContainers: []
+    # - name: hello-once
+    # args:
+    #   - -c
+    #   - "echo 'Hello World!'"
+    # command:
+    #   - /bin/sh
+    # image: 'busybox:glibc'
   # -- Liveness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/))
   livenessProbe:
     initialDelaySeconds: 25


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Add configuration parameters for specifying extra sidecar containers and extra init containers. Implements #607 

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
