### PR TITLE
feat: add the option to disable api server registration for metrics-server

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -67,7 +67,7 @@ their default values.
 | `certificates.certManager.duration` | string | `"8760h0m0s"` | Certificate duration |
 | `certificates.certManager.enabled` | bool | `false` | Enables Cert-manager for certificate management |
 | `certificates.certManager.generateCA` | bool | `true` | Generates a self-signed CA with Cert-manager. If generateCA is false, the secret with the CA has to be annotated with `cert-manager.io/allow-direct-injection: "true"` |
-| `certificates.certManager.issuer` | object | `{"generate":true,"group":"cert-manager.io","kind":"ClusterIssuer","name":"foo-org-ca"}` | Reference to custom Issuer. If issuer.generate is false, then issuer.group, issuer.kind and issuer.name are required |
+| `certificates.certManager.issuer` | object | `{"generate":true,"group":"cert-manager.io","kind":"ClusterIssuer","name":"foo-org-ca"}` | Reference to custom Issuer. |
 | `certificates.certManager.issuer.generate` | bool | `true` | Generates an Issuer resource with Cert-manager |
 | `certificates.certManager.issuer.group` | string | `"cert-manager.io"` | Custom Issuer group. Required when generate: false |
 | `certificates.certManager.issuer.kind` | string | `"ClusterIssuer"` | Custom Issuer kind. Required when generate: false |
@@ -162,6 +162,7 @@ their default values.
 | `metricsServer.dnsPolicy` | string | `"ClusterFirst"` | Defined the DNS policy for the metric server |
 | `metricsServer.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `metricsServer.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |
+| `metricsServer.registerAPIService` | bool | `true` | Register the Metrics API Server as External Metrics Provider / APIService. Useful when you already have an API registered for external metrics and want to do a smooth transition. |
 | `metricsServer.replicaCount` | int | `1` | Capability to configure the number of replicas for KEDA metric server. While you can run more replicas of our metric server, only one instance will used and serve traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover. Learn more in [our documentation](https://keda.sh/docs/latest/operate/cluster/#high-availability). |
 | `metricsServer.revisionHistoryLimit` | int | `10` | ReplicaSets for this Deployment you want to retain (Default: 10) |
 | `metricsServer.useHostNetwork` | bool | `false` | Enable metric server to use host network |

--- a/keda/templates/metrics-server/apiservice.yaml
+++ b/keda/templates/metrics-server/apiservice.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.metricsServer.registerAPIService -}}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
@@ -27,3 +28,4 @@ spec:
   version: v1beta1
   groupPriorityMinimum: 100
   versionPriority: 100
+{{- end -}}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -125,6 +125,9 @@ metricsServer:
     #         values:
     #         - keda-operator-metrics-apiserver
     #     topologyKey: "kubernetes.io/hostname"
+  # -- Register the Metrics API Server as External Metrics Provider / APIService.
+  # Useful when you already have an API registered for external metrics and want to do a smooth transition.
+  registerAPIService: true
   # -- Liveness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/))
   livenessProbe:
     initialDelaySeconds: 5


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Add the `metricsServer.registerAPIService` option to disable external metrics API registration.

This is useful when you already have an API registration (e.g. [Datadog Cluster Agent](https://docs.datadoghq.com/containers/cluster_agent/)) and want to deploy KEDA without impacting the current external metrics API.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*