### PR TITLE
Allow extra egress rules for the keda operator ciliumnetworkpolicy

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -67,7 +67,7 @@ their default values.
 | `certificates.certManager.duration` | string | `"8760h0m0s"` | Certificate duration |
 | `certificates.certManager.enabled` | bool | `false` | Enables Cert-manager for certificate management |
 | `certificates.certManager.generateCA` | bool | `true` | Generates a self-signed CA with Cert-manager. If generateCA is false, the secret with the CA has to be annotated with `cert-manager.io/allow-direct-injection: "true"` |
-| `certificates.certManager.issuer` | object | `{"generate":true,"group":"cert-manager.io","kind":"ClusterIssuer","name":"foo-org-ca"}` | Reference to custom Issuer. If issuer.generate is false, then issuer.group, issuer.kind and issuer.name are required |
+| `certificates.certManager.issuer` | object | `{"generate":true,"group":"cert-manager.io","kind":"ClusterIssuer","name":"foo-org-ca"}` | Reference to custom Issuer. |
 | `certificates.certManager.issuer.generate` | bool | `true` | Generates an Issuer resource with Cert-manager |
 | `certificates.certManager.issuer.group` | string | `"cert-manager.io"` | Custom Issuer group. Required when generate: false |
 | `certificates.certManager.issuer.kind` | string | `"ClusterIssuer"` | Custom Issuer kind. Required when generate: false |
@@ -90,6 +90,7 @@ their default values.
 | `http.timeout` | int | `3000` | The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them) |
 | `image.pullPolicy` | string | `"Always"` | Image pullPolicy for all KEDA components |
 | `imagePullSecrets` | list | `[]` | Name of secret to use to pull images to use to pull Docker images |
+| `networkPolicy.cilium` | object | `{"operator":{"extraEgressRules":[]}}` | Allow use of extra egress rules for cilium network policies |
 | `networkPolicy.enabled` | bool | `false` | Enable network policies |
 | `networkPolicy.flavor` | string | `"cilium"` | Flavor of the network policies (cilium) |
 | `nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |

--- a/keda/templates/manager/ciliumnetworkpolicy.yaml
+++ b/keda/templates/manager/ciliumnetworkpolicy.yaml
@@ -21,6 +21,9 @@ spec:
     - toEntities:
         - kube-apiserver
         - cluster
+    {{- if and .Values.networkPolicy.cilium.operator.extraEgressRules }}
+    {{ toYaml .Values.networkPolicy.cilium.operator.extraEgressRules | nindent 4 }}
+    {{- end }}
   ingress:
     - fromEntities:
         - cluster

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -58,6 +58,10 @@ networkPolicy:
   enabled: false
   # -- Flavor of the network policies (cilium)
   flavor: "cilium"
+  # -- Allow use of extra egress rules for cilium network policies
+  cilium:
+    operator:
+      extraEgressRules: []
 
 operator:
   # -- Name of the KEDA operator


### PR DESCRIPTION
This PR adds support to be able to add extra egress rules to the ciliumnetworkpolicy if for instance, the prometheus used to scale is outside the cluster as the current ciliumnetworkpolicy only allows egress to the cluster pods and the api-server

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
