### PR TITLE
chore: Add missing comment to values.yaml

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -67,7 +67,7 @@ their default values.
 | `certificates.certManager.duration` | string | `"8760h0m0s"` | Certificate duration |
 | `certificates.certManager.enabled` | bool | `false` | Enables Cert-manager for certificate management |
 | `certificates.certManager.generateCA` | bool | `true` | Generates a self-signed CA with Cert-manager. If generateCA is false, the secret with the CA has to be annotated with `cert-manager.io/allow-direct-injection: "true"` |
-| `certificates.certManager.issuer` | object | `{"generate":true,"group":"cert-manager.io","kind":"ClusterIssuer","name":"foo-org-ca"}` | Reference to custom Issuer. |
+| `certificates.certManager.issuer` | object | `{"generate":true,"group":"cert-manager.io","kind":"ClusterIssuer","name":"foo-org-ca"}` | Reference to custom Issuer. If issuer.generate is false, then issuer.group, issuer.kind and issuer.name are required |
 | `certificates.certManager.issuer.generate` | bool | `true` | Generates an Issuer resource with Cert-manager |
 | `certificates.certManager.issuer.group` | string | `"cert-manager.io"` | Custom Issuer group. Required when generate: false |
 | `certificates.certManager.issuer.kind` | string | `"ClusterIssuer"` | Custom Issuer kind. Required when generate: false |

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -756,7 +756,7 @@ certificates:
       #   my-secret-annotation-2: "bar"
       # labels:
       #   my-secret-label: foo
-    # -- Reference to custom Issuer.
+    # -- Reference to custom Issuer. If issuer.generate is false, then issuer.group, issuer.kind and issuer.name are required
     issuer:
       # -- Generates an Issuer resource with Cert-manager
       generate: true


### PR DESCRIPTION
I removed the comment about cert-issuer by error because it wasn't in values.yaml during [this PR](https://github.com/kedacore/charts/pull/610)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
