### PR TITLE
fix(add-on): Allow upgrades removing version labels from selectors

### DIFF
--- a/http-add-on/templates/_helpers.tpl
+++ b/http-add-on/templates/_helpers.tpl
@@ -8,14 +8,21 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Generate basic labels
+Generate match labels
 */}}
-{{- define "keda-http-add-on.labels" }}
-helm.sh/chart: {{ include "keda-http-add-on.chart" . }}
+{{- define "keda-http-add-on.matchLabels" }}
 app.kubernetes.io/part-of: {{ .Chart.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Generate basic labels
+*/}}
+{{- define "keda-http-add-on.labels" }}
+{{- include "keda-http-add-on.matchLabels" . }}
 app.kubernetes.io/version: {{ .Values.images.tag | default .Chart.AppVersion }}
+helm.sh/chart: {{ include "keda-http-add-on.chart" . }}
 {{- if .Values.additionalLabels }}
 {{ toYaml .Values.additionalLabels }}
 {{- end }}

--- a/http-add-on/templates/_helpers.tpl
+++ b/http-add-on/templates/_helpers.tpl
@@ -9,6 +9,8 @@ Create chart name and version as used by the chart label.
 
 {{/*
 Generate match labels
+IMPORTANT: Any change of these labels will block
+future upgrades
 */}}
 {{- define "keda-http-add-on.matchLabels" }}
 app.kubernetes.io/part-of: {{ .Chart.Name }}

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: interceptor
-      {{- include "keda-http-add-on.labels" . | indent 6 }}
+      {{- include "keda-http-add-on.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:

--- a/http-add-on/templates/interceptor/service-admin.yaml
+++ b/http-add-on/templates/interceptor/service-admin.yaml
@@ -13,4 +13,4 @@ spec:
     targetPort: admin
   selector:
     app.kubernetes.io/component: interceptor
-    {{- include "keda-http-add-on.labels" . | indent 4 }}
+    {{- include "keda-http-add-on.matchLabels" . | indent 4 }}

--- a/http-add-on/templates/interceptor/service-proxy.yaml
+++ b/http-add-on/templates/interceptor/service-proxy.yaml
@@ -13,4 +13,4 @@ spec:
     targetPort: proxy
   selector:
     app.kubernetes.io/component: interceptor
-    {{- include "keda-http-add-on.labels" . | indent 4 }}
+    {{- include "keda-http-add-on.matchLabels" . | indent 4 }}

--- a/http-add-on/templates/operator/deployment.yaml
+++ b/http-add-on/templates/operator/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: operator
-      {{- include "keda-http-add-on.labels" . | indent 6 }}
+      {{- include "keda-http-add-on.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:

--- a/http-add-on/templates/operator/service.yaml
+++ b/http-add-on/templates/operator/service.yaml
@@ -13,4 +13,4 @@ spec:
     targetPort: metrics
   selector:
     app.kubernetes.io/component: operator
-    {{- include "keda-http-add-on.labels" . | indent 4 }}
+    {{- include "keda-http-add-on.matchLabels" . | indent 4 }}

--- a/http-add-on/templates/scaler/deployment.yaml
+++ b/http-add-on/templates/scaler/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: scaler
-      {{- include "keda-http-add-on.labels" . | indent 6 }}
+      {{- include "keda-http-add-on.matchLabels" . | indent 6 }}
   template:
     metadata:
       labels:

--- a/http-add-on/templates/scaler/service.yaml
+++ b/http-add-on/templates/scaler/service.yaml
@@ -13,4 +13,4 @@ spec:
     targetPort: grpc
   selector:
     app.kubernetes.io/component: scaler
-    {{- include "keda-http-add-on.labels" . | indent 4 }}
+    {{- include "keda-http-add-on.matchLabels" . | indent 4 }}


### PR DESCRIPTION
`matchLabels` in the HTTP Add-on are wrong because they include version information but `matchLabels` is inmutable, so the upgrades are blocked due to this. The PR adjust the `matchLabels` to just the only ones which doesn't change across the versions.

### Checklist
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))


Fixes https://github.com/kedacore/http-add-on/issues/656
