### PR TITLE
feat: support templated clusterName

### DIFF
--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -91,7 +91,7 @@ spec:
           - "--operator-service-name={{ .Values.operator.name }}"
           - "--metrics-server-service-name={{ .Values.operator.name }}-metrics-apiserver"
           - "--webhooks-service-name={{ .Values.webhooks.name }}"
-          - "--k8s-cluster-name={{ .Values.clusterName }}"
+          - "--k8s-cluster-name={{ tpl .Values.clusterName . }}"
           - "--k8s-cluster-domain={{ .Values.clusterDomain }}"
           - "--enable-prometheus-metrics={{ .Values.prometheus.operator.enabled }}"
           {{- if .Values.prometheus.operator.enabled }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Allows templating of clusterName. This is similar to https://github.com/DataDog/helm-charts/pull/1324 and solves the same purpose

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

