### PR TITLE
fix: add "none" as identity provider

### DIFF
--- a/keda/templates/crds/crd-clustertriggerauthentications.yaml
+++ b/keda/templates/crds/crd-clustertriggerauthentications.yaml
@@ -157,6 +157,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -255,6 +256,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -366,6 +368,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -481,6 +484,7 @@ spec:
                     - aws
                     - aws-eks
                     - aws-kiam
+                    - none
                     type: string
                   roleArn:
                     description: RoleArn sets the AWS RoleArn to be used. Mutually

--- a/keda/templates/crds/crd-triggerauthentications.yaml
+++ b/keda/templates/crds/crd-triggerauthentications.yaml
@@ -477,7 +477,6 @@ spec:
                   provider:
                     description: PodIdentityProvider contains the list of providers
                     enum:
-                    - none
                     - azure
                     - azure-workload
                     - gcp

--- a/keda/templates/crds/crd-triggerauthentications.yaml
+++ b/keda/templates/crds/crd-triggerauthentications.yaml
@@ -474,6 +474,7 @@ spec:
                   provider:
                     description: PodIdentityProvider contains the list of providers
                     enum:
+                    - none
                     - azure
                     - azure-workload
                     - gcp

--- a/keda/templates/crds/crd-triggerauthentications.yaml
+++ b/keda/templates/crds/crd-triggerauthentications.yaml
@@ -156,6 +156,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -254,6 +255,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -365,6 +367,7 @@ spec:
                         - aws
                         - aws-eks
                         - aws-kiam
+                        - none
                         type: string
                       roleArn:
                         description: RoleArn sets the AWS RoleArn to be used. Mutually
@@ -481,6 +484,7 @@ spec:
                     - aws
                     - aws-eks
                     - aws-kiam
+                    - none
                     type: string
                   roleArn:
                     description: RoleArn sets the AWS RoleArn to be used. Mutually


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

identity provider: "none" is officially supported and allowed value based on the docs and keda golang structs:

https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/triggerauthentication_types.go#L123
```
const (
	PodIdentityProviderNone          PodIdentityProvider = "none"
	PodIdentityProviderAzure         PodIdentityProvider = "azure"
	PodIdentityProviderAzureWorkload PodIdentityProvider = "azure-workload"
	PodIdentityProviderGCP           PodIdentityProvider = "gcp"
	PodIdentityProviderAwsEKS        PodIdentityProvider = "aws-eks"
	PodIdentityProviderAwsKiam       PodIdentityProvider = "aws-kiam"
	PodIdentityProviderAws           PodIdentityProvider = "aws"
)
```

and in the docs:
https://keda.sh/docs/2.13/concepts/authentication/

```
apiVersion: keda.sh/v1alpha1
kind: TriggerAuthentication
metadata:
  name: {trigger-authentication-name}
  namespace: default # must be same namespace as the ScaledObject
spec:
  podIdentity:
      provider: none | azure | azure-workload | aws | aws-eks | aws-kiam | gcp  # Optional. Default: none
...
```
its missing since crds refactor (2.13)

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*


