### PR TITLE
feat: Add a way to customize the 'managed-by' label

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -80,6 +80,7 @@ their default values.
 | `clusterName` | string | `"kubernetes-default"` | Kubernetes cluster name. Used in features such as emitting CloudEvents |
 | `crds.additionalAnnotations` | object | `{}` | Custom annotations specifically for CRDs |
 | `crds.install` | bool | `true` | Defines whether the KEDA CRDs have to be installed or not. |
+| `customManagedBy` | string | `""` | When specified, each rendered resource will have `app.kubernetes.io/managed-by: ${this}` label on it. Useful, when using only helm template with some other solution. |
 | `env` | list | `[]` | Additional environment variables that will be passed onto all KEDA components |
 | `extraObjects` | list | `[]` | Array of extra K8s manifests to deploy |
 | `global.image.registry` | string | `nil` | Global image registry of KEDA components |

--- a/keda/templates/_helpers.tpl
+++ b/keda/templates/_helpers.tpl
@@ -25,7 +25,7 @@ Generate basic labels
 */}}
 {{- define "keda.labels" -}}
 {{- include "keda.crd-labels" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ .Values.customManagedBy | default .Release.Name }}
 {{- if .Values.additionalLabels }}
 {{ toYaml .Values.additionalLabels }}
 {{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -812,3 +812,6 @@ extraObjects: []
 
 # -- Capability to turn on/off ASCII art in Helm installation notes
 asciiArt: true
+
+# -- When specified, each rendered resource will have `app.kubernetes.io/managed-by: ${this}` label on it. Useful, when using only helm template with some other solution.
+customManagedBy: ""


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

By default this is a no-operation (so backward compatibility is guaranteed). If the `. customManagedBy` value is not empty, it will be used as a value for `app.kubernetes.io/managed-by` label. This is useful, when using this helm chart as a source for some other tools just for rendering the manifests, but not using the `helm {install,upgrade,uninstall}` or any other day-2 stuff.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- ~[ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*~   *N/A*

