### PR TITLE
correct the value for admission webhooks pod

### DIFF
--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -468,11 +468,11 @@ resources:
   # -- Manage [resource request & limits] of KEDA admission webhooks pod
   webhooks:
     limits:
-      cpu: 50m
-      memory: 100Mi
+      cpu: 1
+      memory: 1000Mi
     requests:
-      cpu: 10m
-      memory: 10Mi
+      cpu: 100m
+      memory: 100Mi
 # -- Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/))
 nodeSelector: {}
 # -- Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/))


### PR DESCRIPTION

update the value for admission webhooks pod .

### Checklist


- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #616 
