### PR TITLE
Flowcontrol needs to be allowed in Metrics Server with k8s

### DIFF
--- a/keda/templates/metrics-server/clusterrole.yaml
+++ b/keda/templates/metrics-server/clusterrole.yaml
@@ -17,4 +17,11 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - flowschemas
+  - prioritylevelconfigurations
+  verbs:
+  - '*'
 {{- end -}}


### PR DESCRIPTION
Hopefully fixes https://github.com/kedacore/keda/issues/5740

@zroubalik is really the KEDA's metric server /adapter who needs this rule or KEDA operator?