### PR TITLE
Allow CA dirs to be specified beyond /custom/ca/

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -121,6 +121,7 @@ their default values.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| `certificates.operator.caDirs` | list | `["/custom/ca"]` | Location(s) of CA files for authentication of external TLS connections such as TLS-enabled metrics sources |
 | `extraArgs.keda` | object | `{}` | Additional KEDA Operator container arguments |
 | `image.keda.registry` | string | `nil` | Image registry of KEDA operator |
 | `image.keda.repository` | string | `"ghcr.io/kedacore/keda"` | Image name of KEDA operator |

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -103,6 +103,9 @@ spec:
           {{- if .Values.profiling.operator.enabled }}
           - "--profiling-bind-address=:{{ .Values.profiling.operator.port }}"
           {{- end }}
+          {{- range .Values.certificates.operator.caDirs }}
+          - "--ca-dir={{ . }}"
+          {{- end }}
           {{- range $key, $value := .Values.extraArgs.keda }}
           - "--{{ $key }}={{ $value }}"
           {{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -814,6 +814,10 @@ certificates:
       kind: ClusterIssuer
       # -- Custom Issuer group. Required when generate: false
       group: cert-manager.io
+  operator:
+    # -- Location(s) of CA files for authentication of external TLS connections such as TLS-enabled metrics sources
+    caDirs:
+    - /custom/ca
 
 permissions:
   metricServer:


### PR DESCRIPTION
https://github.com/kedacore/keda/pull/5859

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [X] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda))

Fixes https://github.com/kedacore/keda/issues/5860