### PR TITLE
Feat: Support for Azure Workload Identity in Cosmos DB External Scaler

### DIFF
--- a/external-scaler-azure-cosmos-db/templates/scaler-deployment.yaml
+++ b/external-scaler-azure-cosmos-db/templates/scaler-deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         {{- include "external-scaler-azure-cosmos-db.labels" . | indent 8 }}
+        {{- if .Values.podIdentity.azureWorkload.enabled }}
+        azure.workload.identity/use: "true"
+        {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
@@ -25,3 +28,6 @@ spec:
           resources:
             {{- .Values.resources | toYaml | nindent 12 }}
       terminationGracePeriodSeconds: 10
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}

--- a/external-scaler-azure-cosmos-db/values.yaml
+++ b/external-scaler-azure-cosmos-db/values.yaml
@@ -24,3 +24,14 @@ resources:
   limits:
     cpu: 100m
     memory: 512Mi
+
+podIdentity:
+  azureWorkload:
+    # -- Set to true to enable Azure Workload Identity usage.
+    # See https://keda.sh/docs/concepts/authentication/#azure-workload-identity
+    # This will be set as a label on the deployment.
+    enabled: false
+
+serviceAccount:
+  # -- The name of the service account to use.
+  name: ""


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Added support for Azure Workload Identity to Azure Cosmos DB external scaler

Changes:
* label  ` azure.workload.identity/use: "true"`
* option to provide a service account


### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

It looks like Readme is auto-generated based on values file. I believe PR to KEDA core is not needed.