### PR TITLE
fix: labels on cloudeventsources CRD should be the same as other CRDs

### DIFF
--- a/keda/templates/crds/crd-cloudeventsources.yaml
+++ b/keda/templates/crds/crd-cloudeventsources.yaml
@@ -6,7 +6,7 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
-    {{- include "keda.labels" . | indent 4 }}
+    {{- include "keda.crd-labels" . | indent 4 }}
   name: cloudeventsources.eventing.keda.sh
 spec:
   group: eventing.keda.sh


### PR DESCRIPTION
Use the same labels for all CRDs.

### Checklist

- [x] I have verified that my change is according to the deprecations & breaking changes policy
- [x] Commits are signed with Developer Certificate of Origin
- [x] README is updated with new configuration values N/A
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) N/A
