### PR TITLE
Comment out new option in helm values, because it breaks the old versions of keda

### DIFF
--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -103,8 +103,10 @@ spec:
           {{- if .Values.profiling.operator.enabled }}
           - "--profiling-bind-address=:{{ .Values.profiling.operator.port }}"
           {{- end }}
-          {{- range .Values.certificates.operator.caDirs }}
+          {{- with (.Values.certificates.operator).caDirs }}
+          {{- range . }}
           - "--ca-dir={{ . }}"
+          {{- end }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs.keda }}
           - "--{{ $key }}={{ $value }}"

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -817,8 +817,8 @@ certificates:
       group: cert-manager.io
   operator:
     # -- Location(s) of CA files for authentication of external TLS connections such as TLS-enabled metrics sources
-    caDirs:
-    - /custom/ca
+    # caDirs:
+    # - /custom/ca
 
 permissions:
   metricServer:


### PR DESCRIPTION
the cmd arg does not exist for older KEDAs

This way the default value is still correctly [applied](https://github.com/kedacore/keda/pull/5859/files#diff-891ba2cfffd82a8ae4131c88beb092d2a88149f579c931e3a1f7ca77fbfc82a5R110) for new keda version because they have the fallback implemented also in the golang code

cc @zroubalik 