### PR TITLE
Correct default registry value in values.yaml

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -122,8 +122,8 @@ their default values.
 |-----------|------|---------|-------------|
 | `certificates.operator.caDirs` | list | `["/custom/ca"]` | Location(s) of CA files for authentication of external TLS connections such as TLS-enabled metrics sources |
 | `extraArgs.keda` | object | `{}` | Additional KEDA Operator container arguments |
-| `image.keda.registry` | string | `nil` | Image registry of KEDA operator |
-| `image.keda.repository` | string | `"ghcr.io/kedacore/keda"` | Image name of KEDA operator |
+| `image.keda.registry` | string | `"ghcr.io"` | Image registry of KEDA operator |
+| `image.keda.repository` | string | `"kedacore/keda"` | Image name of KEDA operator |
 | `image.keda.tag` | string | `""` | Image tag of KEDA operator. Optional, given app version of Helm chart is used by default |
 | `logging.operator.format` | string | `"console"` | Logging format for KEDA Operator. allowed values: `json` or `console` |
 | `logging.operator.level` | string | `"info"` | Logging level for KEDA Operator. allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string |
@@ -160,8 +160,8 @@ their default values.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `extraArgs.metricsAdapter` | object | `{}` | Additional Metrics Adapter container arguments |
-| `image.metricsApiServer.registry` | string | `nil` | Image registry of KEDA Metrics API Server |
-| `image.metricsApiServer.repository` | string | `"ghcr.io/kedacore/keda-metrics-apiserver"` | Image name of KEDA Metrics API Server |
+| `image.metricsApiServer.registry` | string | `"ghcr.io"` | Image registry of KEDA Metrics API Server |
+| `image.metricsApiServer.repository` | string | `"kedacore/keda-metrics-apiserver"` | Image name of KEDA Metrics API Server |
 | `image.metricsApiServer.tag` | string | `""` | Image tag of KEDA Metrics API Server. Optional, given app version of Helm chart is used by default |
 | `logging.metricServer.level` | int | `0` | Logging level for Metrics Server. allowed values: `0` for info, `4` for debug, or an integer value greater than 0, specified as string |
 | `logging.metricServer.stderrthreshold` | string | `"ERROR"` | Logging stderrthreshold for Metrics Server allowed values: 'DEBUG','INFO','WARN','ERROR','ALERT','EMERG' |
@@ -286,8 +286,8 @@ their default values.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `image.webhooks.registry` | string | `nil` | Image registry of KEDA admission-webhooks |
-| `image.webhooks.repository` | string | `"ghcr.io/kedacore/keda-admission-webhooks"` | Image name of KEDA admission-webhooks |
+| `image.webhooks.registry` | string | `"ghcr.io"` | Image registry of KEDA admission-webhooks |
+| `image.webhooks.repository` | string | `"kedacore/keda-admission-webhooks"` | Image name of KEDA admission-webhooks |
 | `image.webhooks.tag` | string | `""` | Image tag of KEDA admission-webhooks . Optional, given app version of Helm chart is used by default |
 | `logging.webhooks.format` | string | `"console"` | Logging format for KEDA Admission webhooks. allowed values: `json` or `console` |
 | `logging.webhooks.level` | string | `"info"` | Logging level for KEDA Operator. allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string |

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -10,23 +10,23 @@ global:
 image:
   keda:
     # -- Image registry of KEDA operator
-    registry: null
+    registry: ghcr.io
     # -- Image name of KEDA operator
-    repository: ghcr.io/kedacore/keda
+    repository: kedacore/keda
     # -- Image tag of KEDA operator. Optional, given app version of Helm chart is used by default
     tag: ""
   metricsApiServer:
     # -- Image registry of KEDA Metrics API Server
-    registry: null
+    registry: ghcr.io
     # -- Image name of KEDA Metrics API Server
-    repository: ghcr.io/kedacore/keda-metrics-apiserver
+    repository: kedacore/keda-metrics-apiserver
     # -- Image tag of KEDA Metrics API Server. Optional, given app version of Helm chart is used by default
     tag: ""
   webhooks:
     # -- Image registry of KEDA admission-webhooks
-    registry: null
+    registry: ghcr.io
     # -- Image name of KEDA admission-webhooks
-    repository: ghcr.io/kedacore/keda-admission-webhooks
+    repository: kedacore/keda-admission-webhooks
     # -- Image tag of KEDA admission-webhooks . Optional, given app version of Helm chart is used by default
     tag: ""
   # -- Image pullPolicy for all KEDA components


### PR DESCRIPTION
It updates the `values.yaml` file to correctly separate the `registry` and `repository` values for the KEDA image.

Changes Made:

- Set the default value of `image.keda.registry` to `ghcr.io`.
- Adjusted `image.keda.repository` to `kedacore/keda`.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)

