### PR TITLE
http-add-on: ability to specify number of operator replicas

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -117,6 +117,7 @@ their default values.
 | `operator.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |
 | `operator.port` | int | `8443` | The port for the operator main server to run on |
 | `operator.pullPolicy` | string | `"Always"` | The image pull policy for the operator component |
+| `operator.replicas` | int | `1` | Number of replicas, oerator k8s resources will not be installed if this is set to 0 |
 | `operator.resources.limits` | object | `{"cpu":0.5,"memory":"64Mi"}` | The CPU/memory resource limit for the operator component |
 | `operator.resources.requests` | object | `{"cpu":"250m","memory":"20Mi"}` | The CPU/memory resource request for the operator component |
 | `operator.tolerations` | list | `[]` | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |

--- a/http-add-on/templates/operator/deployment.yaml
+++ b/http-add-on/templates/operator/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.operator.replicas) 0 }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,7 +8,7 @@ metadata:
   name: {{ .Chart.Name }}-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.operator.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: operator
@@ -99,3 +100,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/http-add-on/templates/operator/rbac.yml
+++ b/http-add-on/templates/operator/rbac.yml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.operator.replicas) 0 }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -175,3 +176,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/http-add-on/templates/operator/service.yaml
+++ b/http-add-on/templates/operator/service.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.operator.replicas) 0 }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
   selector:
     app.kubernetes.io/component: operator
     {{- include "keda-http-add-on.matchLabels" . | indent 4 }}
+{{- end }}

--- a/http-add-on/templates/operator/serviceaccount.yaml
+++ b/http-add-on/templates/operator/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.operator.replicas) 0 }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,3 +7,4 @@ metadata:
     {{- include "keda-http-add-on.labels" . | indent 4 }}
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -44,6 +44,8 @@ logging:
 
 # operator-specific configuration values
 operator:
+  # -- Number of replicas, oerator k8s resources will not be installed if this is set to 0
+  replicas: 1
   # -- The image pull secrets for the operator component
   imagePullSecrets: []
   # -- The namespace to watch for new `HTTPScaledObject`s. Leave this blank (i.e. `""`) to tell the operator to watch all namespaces.


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

This also skips creation of the HTTP Operator Deployment, Service, ServiceAccount and RBAC if desired number of replicas is < 1

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)

