### PR TITLE
Add a pdb template for the http-add-on interceptor

### DIFF
--- a/http-add-on/templates/interceptor/poddisruptionbudget.yaml
+++ b/http-add-on/templates/interceptor/poddisruptionbudget.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.interceptor.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: interceptor
+    {{- include "keda-http-add-on.labels" . | indent 4 }}
+  name: {{ .Chart.Name }}-interceptor
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: interceptor
+      {{- include "keda-http-add-on.matchLabels" . | indent 6 }}
+  {{- if .Values.interceptor.pdb.minAvailable }}
+  minAvailable: {{ .Values.interceptor.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.interceptor.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.interceptor.pdb.maxUnavailable }}
+  {{- end }}
+{{- end -}}

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -83,7 +83,7 @@ operator:
         memory: 20Mi
 
 scaler:
-  # -- Number of replicas 
+  # -- Number of replicas
   replicas: 3
   # -- The image pull secrets for the scaler component
   imagePullSecrets: []
@@ -192,6 +192,15 @@ interceptor:
     cert_secret: keda-tls-certs
     # -- Port that the interceptor proxy TLS server should be started on
     port: 8443
+
+  # configuration of pdb for the interceptor
+  pdb:
+    # -- Whether to install the `PodDisruptionBudget` for the interceptor
+    enabled: true
+    # -- The minimum number of replicas that should be available for the interceptor
+    minAvailable: 0
+    # -- The maximum number of replicas that can be unavailable for the interceptor
+    maxUnavailable: 1
 
 # configuration for the images to use for each component
 images:


### PR DESCRIPTION
There is no pod disruption budget on the http addon interceptors, which
means that during node rollover, there might not be any interceptors
available to add requests to its queue. Since the queues themselves are
in memory, that means that there would be dropped requests.

Closes #658
