### PR TITLE
Add missing quotes for interceptor's TLS-related env vars

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -66,11 +66,11 @@ spec:
         - name: KEDA_HTTP_PROXY_TLS_ENABLED
           value: "true"
         - name: KEDA_HTTP_PROXY_TLS_CERT_PATH
-          value: {{ .Values.interceptor.tls.cert_path }}
+          value: "{{ .Values.interceptor.tls.cert_path }}"
         - name: KEDA_HTTP_PROXY_TLS_KEY_PATH
-          value: {{ .Values.interceptor.tls.key_path }}
+          value: "{{ .Values.interceptor.tls.key_path }}"
         - name: KEDA_HTTP_PROXY_TLS_PORT
-          value: {{ .Values.interceptor.tls.port }}
+          value: "{{ .Values.interceptor.tls.port }}"
         {{- end }}
         ports:
         - containerPort: {{ .Values.interceptor.admin.port }}


### PR DESCRIPTION
The env vars were not quoted which ended up in ports not being quoted and helm chart was not installable.

```
 {{ .. | quote }}
```
.. would also work, but this way it's consistent w/ the other variables in this file

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Reproduction of the issue, this pr fixes:

```
helm upgrade -i http-add-on . --namespace keda  --set crds.install=false --set interceptor.tls.enabled=true
Release "http-add-on" does not exist. Installing it now.
Error: 1 error occurred:
	* Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```