### PR TITLE
fix: broken "| default" logic for automountServiceAccountToken

### DIFF
--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ (.Values.serviceAccount.operator).name | default .Values.serviceAccount.name }}
-      automountServiceAccountToken: {{ (.Values.serviceAccount.operator).automountServiceAccountToken | default .Values.serviceAccount.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ kindIs "invalid" (.Values.serviceAccount.operator).automountServiceAccountToken | ternary .Values.serviceAccount.automountServiceAccountToken (.Values.serviceAccount.operator).automountServiceAccountToken }}
       securityContext:
         {{- if .Values.podSecurityContext.operator }}
         {{- toYaml .Values.podSecurityContext.operator | nindent 8 }}

--- a/keda/templates/manager/serviceaccount.yaml
+++ b/keda/templates/manager/serviceaccount.yaml
@@ -45,5 +45,5 @@ metadata:
   {{- end }}
   name: {{ (.Values.serviceAccount.operator).name | default .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
-automountServiceAccountToken: {{ (.Values.serviceAccount.operator).automountServiceAccountToken | default .Values.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ kindIs "invalid" (.Values.serviceAccount.operator).automountServiceAccountToken | ternary .Values.serviceAccount.automountServiceAccountToken (.Values.serviceAccount.operator).automountServiceAccountToken }}
 {{- end -}}

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ (.Values.serviceAccount.metricServer).name | default .Values.serviceAccount.name }}
-      automountServiceAccountToken: {{ (.Values.serviceAccount.metricServer).automountServiceAccountToken | default .Values.serviceAccount.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ kindIs "invalid" (.Values.serviceAccount.metricServer).automountServiceAccountToken | ternary .Values.serviceAccount.automountServiceAccountToken (.Values.serviceAccount.metricServer).automountServiceAccountToken }}
       securityContext:
         {{- if .Values.podSecurityContext.metricServer }}
         {{- toYaml .Values.podSecurityContext.metricServer | nindent 8 }}

--- a/keda/templates/metrics-server/serviceaccount.yaml
+++ b/keda/templates/metrics-server/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     {{- end }}
   name: {{ (.Values.serviceAccount.metricServer).name | default .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
-automountServiceAccountToken: {{ (.Values.serviceAccount.metricServer).automountServiceAccountToken | default .Values.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ kindIs "invalid" (.Values.serviceAccount.metricServer).automountServiceAccountToken | ternary .Values.serviceAccount.automountServiceAccountToken (.Values.serviceAccount.metricServer).automountServiceAccountToken }}
 {{- end -}}

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ (.Values.serviceAccount.webhooks).name | default .Values.serviceAccount.name }}
-      automountServiceAccountToken: {{ (.Values.serviceAccount.webhooks).automountServiceAccountToken | default .Values.serviceAccount.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ kindIs "invalid" (.Values.serviceAccount.webhooks).automountServiceAccountToken | ternary .Values.serviceAccount.automountServiceAccountToken (.Values.serviceAccount.webhooks).automountServiceAccountToken }}
       securityContext:
         {{- if .Values.podSecurityContext.webhooks }}
         {{- toYaml .Values.podSecurityContext.webhooks | nindent 8 }}

--- a/keda/templates/webhooks/serviceaccount.yaml
+++ b/keda/templates/webhooks/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     {{- end }}
   name: {{ (.Values.serviceAccount.webhooks).name | default .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
-automountServiceAccountToken: {{ (.Values.serviceAccount.webhooks).automountServiceAccountToken | default .Values.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ kindIs "invalid" (.Values.serviceAccount.webhooks).automountServiceAccountToken | ternary .Values.serviceAccount.automountServiceAccountToken (.Values.serviceAccount.webhooks).automountServiceAccountToken }}
 {{- end -}}


### PR DESCRIPTION
Fixes following issue:

When setting (for example) (.Values.serviceAccount.operator).automountServiceAccountToken to boolean false, the "| default" part kicks in.

Fix is strongly inspired from https://github.com/helm/helm/issues/12080#issuecomment-1555147255

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [X] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
