### PR TITLE
istio compatibility with appProtocol: https

### DIFF
--- a/keda/templates/metrics-server/service.yaml
+++ b/keda/templates/metrics-server/service.yaml
@@ -32,6 +32,7 @@ spec:
     port: {{ .Values.service.portHttps }}
     targetPort: {{ .Values.service.portHttpsTarget }}
     protocol: TCP
+    appProtocol: https
   - name: {{ .Values.prometheus.metricServer.portName }}
     port: {{ .Values.prometheus.metricServer.port }}
     targetPort: {{ .Values.prometheus.metricServer.port }}

--- a/keda/templates/webhooks/service.yaml
+++ b/keda/templates/webhooks/service.yaml
@@ -31,6 +31,7 @@ spec:
     port: 443
     protocol: TCP
     targetPort: {{ .Values.webhooks.port | default 9443 }}
+    appProtocol: https
   {{- if .Values.prometheus.webhooks.enabled }}
   - name: {{ .Values.prometheus.webhooks.serviceMonitor.port }}
     port: {{ .Values.prometheus.webhooks.port }}


### PR DESCRIPTION
Despite Istio docs stating that setting the name of the port to https should result in the protocol being https (TLS not intercepted), it doesn't appear to work for us, and only works by explicitly setting appProtocol.

https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
