### PR TITLE
Add appProtocol to services collecting metrics using mTLS

### DIFF
--- a/keda/templates/manager/service.yaml
+++ b/keda/templates/manager/service.yaml
@@ -33,6 +33,9 @@ spec:
   - name: metrics
     port: {{ .Values.prometheus.operator.port }}
     targetPort: {{ .Values.prometheus.operator.port }}
+    {{- with .Values.prometheus.operator.appProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
   {{- end }}
   {{- if .Values.profiling.operator.enabled }}
   - name: profiling

--- a/keda/templates/metrics-server/service.yaml
+++ b/keda/templates/metrics-server/service.yaml
@@ -37,6 +37,9 @@ spec:
     port: {{ .Values.prometheus.metricServer.port }}
     targetPort: {{ .Values.prometheus.metricServer.port }}
     protocol: TCP
+    {{- with .Values.prometheus.metricServer.appProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
   {{- if .Values.profiling.metricsServer.enabled }}
   - name: profiling
     port: {{ .Values.profiling.metricsServer.port }}

--- a/keda/templates/webhooks/service.yaml
+++ b/keda/templates/webhooks/service.yaml
@@ -36,6 +36,9 @@ spec:
   - name: {{ .Values.prometheus.webhooks.serviceMonitor.port }}
     port: {{ .Values.prometheus.webhooks.port }}
     targetPort: {{ .Values.prometheus.webhooks.port }}
+        {{- with .Values.prometheus.webhooks.appProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
   {{- end }}
   {{- if .Values.profiling.webhooks.enabled }}
   - name: profiling

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -601,6 +601,8 @@ prometheus:
     port: 8080
     # -- HTTP port name for exposing metrics server prometheus metrics
     portName: metrics
+    # -- App Protocol for service when scraping metrics endpoint
+    # appProtocol: http
     serviceMonitor:
       # -- Enables ServiceMonitor creation for the Prometheus Operator
       enabled: false
@@ -654,6 +656,8 @@ prometheus:
     enabled: false
     # -- Port used for exposing KEDA Operator prometheus metrics
     port: 8080
+    # -- App Protocol for service when scraping metrics endpoint
+    # appProtocol: http
     serviceMonitor:
       # -- Enables ServiceMonitor creation for the Prometheus Operator
       enabled: false
@@ -725,6 +729,8 @@ prometheus:
     enabled: false
     # -- Port used for exposing KEDA admission webhooks prometheus metrics
     port: 8080
+    # -- App Protocol for service when scraping metrics endpoint
+    # appProtocol: http
     serviceMonitor:
       # -- Enables ServiceMonitor creation for the Prometheus webhooks
       enabled: false


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->
Adds `appProtocol` to the services collecting metrics using mTLS https://github.com/prometheus/prometheus/issues/10213#issuecomment-1064280828

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
