### PR TITLE
Add Secret GET to keda-operator minimal RBAC

### DIFF
--- a/keda/templates/manager/minimal-rbac.yaml
+++ b/keda/templates/manager/minimal-rbac.yaml
@@ -35,6 +35,7 @@ rules:
   - create
   - update
 {{- if .Values.permissions.operator.restrict.secret }}
+  - get
   - list
   - watch
 {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

This is a followup to: https://github.com/kedacore/charts/pull/643

Technically this PR is not necessary because the `keda-operator` uses an informer cache and `GET` requests are handled internally (the cache is formed by `LIST` and then `WATCH`), but this is to remain consistent with the documentation where all three `LIST`, `WATCH` and `GET` are explicitly mentioned.
https://keda.sh/docs/2.15/operate/cluster/#restrict-secret-access

Worthy to mention adding `GET` along `LIST` doesn't elevate any permissions. It's an implementation detail of the RBAC in kube-apiserver.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Relates to: https://github.com/kedacore/charts/issues/685
