### PR TITLE
http-add-on: support portName on HTTPScaledObject

### DIFF
--- a/http-add-on/templates/crd.yaml
+++ b/http-add-on/templates/crd.yaml
@@ -93,8 +93,9 @@ spec:
                     type: integer
                 type: object
               scaleTargetRef:
-                description: The name of the deployment to route HTTP requests to
-                  (and to autoscale).
+                description: |-
+                  The name of the deployment to route HTTP requests to (and to autoscale).
+                  Including validation as a requirement to define either the PortName or the Port
                 properties:
                   apiVersion:
                     type: string
@@ -110,13 +111,18 @@ spec:
                     description: The port to route to
                     format: int32
                     type: integer
+                  portName:
+                    description: The port to route to referenced by name
+                    type: string
                   service:
                     description: The name of the service to route to
                     type: string
                 required:
-                - port
                 - service
                 type: object
+                x-kubernetes-validations:
+                - message: must define either the 'portName' or the 'port'
+                  rule: has(self.portName) != has(self.port)
               scaledownPeriod:
                 description: (optional) Cooldown period value
                 format: int32
@@ -152,7 +158,7 @@ spec:
                     type: object
                 type: object
               targetPendingRequests:
-                description: (optional) DEPRECATED (use SscalingMetric instead) Target
+                description: (optional) DEPRECATED (use ScalingMetric instead) Target
                   metric value
                 format: int32
                 type: integer
@@ -210,4 +216,3 @@ spec:
     subresources:
       status: {}
 {{ end }}
-  

--- a/http-add-on/templates/interceptor/rbac.yml
+++ b/http-add-on/templates/interceptor/rbac.yml
@@ -14,6 +14,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - http.keda.sh
   resources:
   - httpscaledobjects


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

1. add RBAC for watching `Services`
2. HTTPScaledObject supports referencing port as `portName` to follow common conventions in k8s API

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

see also: https://github.com/kedacore/http-add-on/pull/1174