### PR TITLE
Reverting setting HPA namespace variable

### DIFF
--- a/keda/templates/metrics-server/clusterrolebinding.yaml
+++ b/keda/templates/metrics-server/clusterrolebinding.yaml
@@ -59,5 +59,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: horizontal-pod-autoscaler
-  namespace: {{ .Values.rbac.controlPlaneServiceAccountsNamespace }}
+  namespace: kube-system
 {{- end -}}


### PR DESCRIPTION
Sadly both metrics-server and HPA namespaces were updated in the previous MR where I added an option to use custom metrics-server namespace, this should be partially reverted since it should be required only for RoleBinding of metrics-server, not ClusterRoleBinding of HPA.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #

- Removed .Values.rbac.controlPlaneServiceAccountsNamespace variable binding for HPA ClusterRoleBinding
