### PR TITLE
feat: support `BoundServiceAccountToken` triggerAuth provider

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -141,6 +141,7 @@ their default values.
 | `operator.revisionHistoryLimit` | int | `10` | ReplicaSets for this Deployment you want to retain (Default: 10) |
 | `permissions.operator.restrict.namesAllowList` | list | `[]` | Array of strings denoting what secrets the KEDA operator will be able to read, this takes into account also the configured `watchNamespace`. the default is an empty array -> no restriction on the secret name |
 | `permissions.operator.restrict.secret` | bool | `false` | Restrict Secret Access for KEDA operator if true, KEDA operator will be able to read only secrets in {{ .Release.Namespace }} namespace |
+| `permissions.operator.restrict.serviceAccountTokenCreationRoles` | list | `[]` | Creates roles and rolebindings from namespaced service accounts in the array which allow the KEDA operator to request service account tokens |
 | `podAnnotations.keda` | object | `{}` | Pod annotations for KEDA operator |
 | `podDisruptionBudget.operator` | object | `{}` | Capability to configure [Pod Disruption Budget] |
 | `podLabels.keda` | object | `{}` | Pod labels for KEDA operator |

--- a/keda/templates/crds/crd-clustertriggerauthentications.yaml
+++ b/keda/templates/crds/crd-clustertriggerauthentications.yaml
@@ -308,6 +308,18 @@ spec:
                 - secrets
                 - vaultUri
                 type: object
+              boundServiceAccountToken:
+                items:
+                  properties:
+                    parameter:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                  required:
+                  - parameter
+                  - serviceAccountName
+                  type: object
+                type: array
               configMapTargetRef:
                 items:
                   description: AuthConfigMapTargetRef is used to authenticate using

--- a/keda/templates/crds/crd-triggerauthentications.yaml
+++ b/keda/templates/crds/crd-triggerauthentications.yaml
@@ -307,6 +307,18 @@ spec:
                 - secrets
                 - vaultUri
                 type: object
+              boundServiceAccountToken:
+                items:
+                  properties:
+                    parameter:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                  required:
+                  - parameter
+                  - serviceAccountName
+                  type: object
+                type: array
               configMapTargetRef:
                 items:
                   description: AuthConfigMapTargetRef is used to authenticate using

--- a/keda/templates/manager/clusterrole.yaml
+++ b/keda/templates/manager/clusterrole.yaml
@@ -210,4 +210,51 @@ rules:
   - list
   - watch
 {{- end -}}
+{{- if .Values.permissions.operator.restrict.serviceAccountTokenCreationRoles }}
+{{- range $r := .Values.permissions.operator.restrict.serviceAccountTokenCreationRoles }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  {{- with $.Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ $.Values.operator.name }}
+    {{- include "keda.labels" $ | indent 4 }}
+  name: {{ $.Values.operator.name }}-token-creator-{{ $r.name }}
+  namespace: {{ $r.namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+  resourceNames:
+  - {{ $r.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  {{- with $.Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ $.Values.operator.name }}
+    {{- include "keda.labels" $ | indent 4 }}
+  name: {{ $.Values.operator.name }}-token-creator-{{ $r.name }}
+  namespace: {{ $r.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $.Values.operator.name }}-token-creator-{{ $r.name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.operator.name }}
+  namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -846,6 +846,12 @@ permissions:
       # also the configured `watchNamespace`.
       # the default is an empty array -> no restriction on the secret name
       namesAllowList: []
+      # -- Creates roles and rolebindings from namespaced service accounts in the array which allow the KEDA operator
+      # to request service account tokens for use with the boundServiceAccountToken trigger source.
+      # If the namespace does not exist, this will cause the helm chart installation to fail.
+      serviceAccountTokenCreationRoles: []
+      # - name: myServiceAccount
+      #   namespace: myServiceAccountNamespace
 
 # -- Array of extra K8s manifests to deploy
 extraObjects: []
@@ -867,3 +873,4 @@ customManagedBy: ""
 # -- Enable service links in pods. Although enabled, mirroring k8s default, it is highly recommended to disable,
 # due to its legacy status [Legacy container links](https://docs.docker.com/engine/network/links/)
 enableServiceLinks: true
+


### PR DESCRIPTION
Updates CRDs to support `BoundServiceAccountToken` trigger auth provider/source. Also adds a helm value of type array called `serviceAccountTokenCreationRoles` which allows you to add objects of `name` and `namespace` corresponding to service accounts in the cluster that you'd like the `keda-operator` to be able to request service account tokens from. 
### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Related to https://github.com/kedacore/keda/pull/6272
