### PR TITLE
feat: allow configuring min tls for grpc

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -90,6 +90,7 @@ their default values.
 | `http.minTlsVersion` | string | `"TLS12"` | The minimum TLS version to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and this value does not necessarily apply to them) |
 | `http.timeout` | int | `3000` | The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them) |
 | `image.pullPolicy` | string | `"Always"` | Image pullPolicy for all KEDA components |
+| `grpc.minTlsVersion` | string | `"TLS13"` | The minimum TLS version to use for all GRPC clients/servers |
 | `imagePullSecrets` | list | `[]` | Name of secret to use to pull images to use to pull Docker images |
 | `networkPolicy.cilium` | object | `{"operator":{"extraEgressRules":[]}}` | Allow use of extra egress rules for cilium network policies |
 | `networkPolicy.enabled` | bool | `false` | Enable network policies |

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -156,6 +156,8 @@ spec:
               value: {{ .Values.http.timeout | quote }}
             - name: KEDA_HTTP_MIN_TLS_VERSION
               value: {{ .Values.http.minTlsVersion }}
+            - name: KEDA_GRPC_MIN_TLS_VERSION
+              value: {{ .Values.grpc.minTlsVersion }}            
             {{- if ( not .Values.http.keepAlive.enabled ) }}
             - name: KEDA_HTTP_DISABLE_KEEP_ALIVE
               value: "true"

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -105,6 +105,8 @@ spec:
               value: {{ .Values.http.timeout | quote }}
             - name: KEDA_HTTP_MIN_TLS_VERSION
               value: {{ .Values.http.minTlsVersion }}
+            - name: KEDA_GRPC_MIN_TLS_VERSION
+              value: {{ .Values.grpc.minTlsVersion }}
             {{- if ( not .Values.http.keepAlive.enabled ) }}
             - name: KEDA_HTTP_DISABLE_KEEP_ALIVE
               value: "true"

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -544,6 +544,10 @@ http:
   # -- The minimum TLS version to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and this value does not necessarily apply to them)
   minTlsVersion: TLS12
 
+grpc:
+  # -- The minimum TLS version to use for GRPC clients / servers
+  minTlsVersion: TLS13
+
 ## This setting lets you enable profiling for all of the components of KEDA and in the specific port you choose
 ## This can be useful when trying to investigate errors like memory leaks or CPU or even look at goroutines to understand better
 ## This setting is disabled by default


### PR DESCRIPTION
Allow configuring min version for GRPC TLS.
Supporting: https://github.com/kedacore/keda/pull/6320 (pending merge)

### Checklist
- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] [A PR is opened to update KEDA core repo](ttps://github.com/kedacore/keda/pull/6320)

