### PR TITLE
 fix: add forgotten crds.additionalAnnotations to crd-clustercloudeventsources.yaml

### DIFF
--- a/keda/templates/crds/crd-clustercloudeventsources.yaml
+++ b/keda/templates/crds/crd-clustercloudeventsources.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
+    {{- if (or .Values.crds.additionalAnnotations .Values.additionalAnnotations) }}
+    {{- toYaml (merge .Values.crds.additionalAnnotations .Values.additionalAnnotations) | nindent 4 }}
+    {{- end }}
   labels:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.crd-labels" . | indent 4 }}


### PR DESCRIPTION
Similar to https://github.com/kedacore/charts/pull/668

Add forgotten block to template crds.additionalAnnotations into crd-clustercloudeventsources.yaml annotations.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [X] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
