### PR TITLE
keda: cert-manager: rotate CA every 9 months

### DIFF
--- a/keda/templates/cert-manager/self-ca.yaml
+++ b/keda/templates/cert-manager/self-ca.yaml
@@ -14,7 +14,7 @@ spec:
     algorithm: RSA
     size: 2048
   duration: 8760h0m0s # 1 year
-  renewBefore: 720h0m0s # 1 month
+  renewBefore: 2160h0m0s # 3 months
   issuerRef:
     name: {{ .Values.operator.name }}-selfsigned-issuer
     kind: Issuer


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

The CA is self-signed for 1 year with a rotation set 1 month before its own expiration.
The cert signed by the CA is also signed for 1 year with a rotation ~10~ 8 months before expiration (so rotating every ~2~ 4 months).

That theoretically means the CA, a month before its expiration, can sign a cert for 1 year (scheduled to rotate in ~2~ 4 months). But the cert will be rejected during TLS handshake in a month + 1 day because when evaluating the chain, the signing CA has expired at that point.

This PR adds extra rotation buffer, rotating CA every ~9~ 7 months (~3~ 5 months before expiration) so when it signs certs scheduled to rotate in ~2~ 4 months, it doesn't expire meanwhile.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #710
