### PR TITLE
fix(cert-manager): Ensure there is at least one leaf certificate renewal when renewing the CA

### DIFF
--- a/keda/templates/cert-manager/self-ca.yaml
+++ b/keda/templates/cert-manager/self-ca.yaml
@@ -13,7 +13,8 @@ spec:
   privateKey:
     algorithm: RSA
     size: 2048
-  duration: 43800h0m0s # 5 years
+  duration: 43800h0m0s     # 5 years
+  renewBefore: 14600h0m0s  # 1.6 year, 1/3rd of the duration
   issuerRef:
     name: {{ .Values.operator.name }}-selfsigned-issuer
     kind: Issuer

--- a/keda/templates/cert-manager/self-ca.yaml
+++ b/keda/templates/cert-manager/self-ca.yaml
@@ -13,8 +13,7 @@ spec:
   privateKey:
     algorithm: RSA
     size: 2048
-  duration: 8760h0m0s # 1 year
-  renewBefore: 720h0m0s # 1 month
+  duration: 43800h0m0s # 5 years
   issuerRef:
     name: {{ .Values.operator.name }}-selfsigned-issuer
     kind: Issuer


### PR DESCRIPTION
The renewBefore value for the root ca was simply too low barely giving the leaf certificate any time to renew itself. This leads to the root ca expiring before the leaf certificates expires.

By removing the renewBefore values we go back to the 2/3 default and as long as the leaf certificate is only valid for half of the root it should be fine.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #710
