### PR TITLE
fix(rbac): add missing eventing.keda.sh permissions

### DIFF
--- a/keda/templates/manager/minimal-rbac.yaml
+++ b/keda/templates/manager/minimal-rbac.yaml
@@ -113,6 +113,19 @@ rules:
   - update
   - watch
 {{- end }}
+- apiGroups:
+  - eventing.keda.sh
+  resources:
+  - cloudeventsources
+  - cloudeventsources/status
+  - clustercloudeventsources
+  - clustercloudeventsources/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Add r/w permissions for cloudeventsources and clustercloudeventsources in the minimal-rbac ClusterRole template.

These are required to prevent a crashloop when shipping the operator with the `watchNamespace` property.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes kedacore/keda#6084