### PR TITLE
add keda default labels to cert-manager objects

### DIFF
--- a/keda/templates/cert-manager/keda-issuer.yaml
+++ b/keda/templates/cert-manager/keda-issuer.yaml
@@ -8,6 +8,8 @@ metadata:
   {{- end }}
   name: {{ .Values.operator.name }}-issuer
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "keda.labels" . | indent 4 }}
 spec:
   ca:
     secretName: {{ .Values.certificates.certManager.caSecretName }}

--- a/keda/templates/cert-manager/keda-tls-certificate.yaml
+++ b/keda/templates/cert-manager/keda-tls-certificate.yaml
@@ -4,6 +4,8 @@ kind: Certificate
 metadata:
   name: {{ .Values.operator.name }}-tls-certificates
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "keda.labels" . | indent 4 }}
 spec:
   commonName: {{ .Values.operator.name }}
   dnsNames:

--- a/keda/templates/cert-manager/self-ca.yaml
+++ b/keda/templates/cert-manager/self-ca.yaml
@@ -4,6 +4,8 @@ kind: Certificate
 metadata:
   name: {{ .Values.operator.name }}-ca
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "keda.labels" . | indent 4 }}
 spec:
   isCA: true
   commonName: {{ .Values.operator.name }}

--- a/keda/templates/cert-manager/self-issuer.yaml
+++ b/keda/templates/cert-manager/self-issuer.yaml
@@ -8,6 +8,8 @@ metadata:
   {{- end }}
   name: {{ .Values.operator.name }}-selfsigned-issuer
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "keda.labels" . | indent 4 }}
 spec:
   selfSigned: {}
 {{- end }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [X] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
