### PR TITLE
Add webhook timeouts

### DIFF
--- a/keda/templates/webhooks/validatingconfiguration.yaml
+++ b/keda/templates/webhooks/validatingconfiguration.yaml
@@ -43,7 +43,7 @@ webhooks:
     resources:
     - scaledobjects
   sideEffects: None
-  timeoutSeconds: 10
+  timeoutSeconds: {{ .Values.webhooks.timeoutSeconds | default 10 }}
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -67,7 +67,7 @@ webhooks:
     resources:
     - triggerauthentications
   sideEffects: None
-  timeoutSeconds: 10
+  timeoutSeconds: {{ .Values.webhooks.timeoutSeconds | default 10 }}
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -91,5 +91,5 @@ webhooks:
     resources:
     - clustertriggerauthentications
   sideEffects: None
-  timeoutSeconds: 10
+  timeoutSeconds: {{ .Values.webhooks.timeoutSeconds | default 10 }}
 {{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -183,6 +183,8 @@ webhooks:
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1
+  # -- Timeout in seconds for KEDA admission webhooks
+  timeoutSeconds: 10
   # -- Enable webhook to use host network, this is required on EKS with custom CNI
   useHostNetwork: false
   # -- Name of the KEDA admission webhooks


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Adds timeout to admission webhooks

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
