### PR TITLE
HTTP Add-On: add `stackTracesEnabled` logging option

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -29,9 +29,12 @@ spec:
       {{- end }}
       containers:
       - args:
-          - "--zap-log-level={{ .Values.logging.interceptor.level }}"
-          - "--zap-encoder={{ .Values.logging.interceptor.format }}"
-          - "--zap-time-encoding={{ .Values.logging.interceptor.timeEncoding }}"
+        - "--zap-log-level={{ .Values.logging.interceptor.level }}"
+        - "--zap-encoder={{ .Values.logging.interceptor.format }}"
+        - "--zap-time-encoding={{ .Values.logging.interceptor.timeEncoding }}"
+        {{- if .Values.logging.interceptor.stackTracesEnabled }}
+        - "--zap-stacktrace-level=error"
+        {{- end }}
         image: "{{ .Values.images.interceptor }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         imagePullPolicy: '{{ .Values.interceptor.pullPolicy | default "Always" }}'
         name: "{{ .Chart.Name }}-interceptor"

--- a/http-add-on/templates/operator/deployment.yaml
+++ b/http-add-on/templates/operator/deployment.yaml
@@ -52,6 +52,9 @@ spec:
         - --zap-log-level={{ .Values.logging.operator.level }}
         - --zap-time-encoding={{ .Values.logging.operator.timeEncoding }}
         - --zap-encoder={{ .Values.logging.operator.format }}
+        {{- if .Values.logging.operator.stackTracesEnabled }}
+        - "--zap-stacktrace-level=error"
+        {{- end }}
         image: "{{ .Values.images.operator }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         imagePullPolicy: '{{ .Values.operator.pullPolicy | default "Always" }}'
         name: "{{ .Chart.Name }}-operator"

--- a/http-add-on/templates/scaler/deployment.yaml
+++ b/http-add-on/templates/scaler/deployment.yaml
@@ -30,9 +30,12 @@ spec:
       {{- end }}
       containers:
       - args:
-          - "--zap-log-level={{ .Values.logging.scaler.level }}"
-          - "--zap-encoder={{ .Values.logging.scaler.format }}"
-          - "--zap-time-encoding={{ .Values.logging.scaler.timeEncoding }}"
+        - "--zap-log-level={{ .Values.logging.scaler.level }}"
+        - "--zap-encoder={{ .Values.logging.scaler.format }}"
+        - "--zap-time-encoding={{ .Values.logging.scaler.timeEncoding }}"
+        {{- if .Values.logging.scaler.stackTracesEnabled }}
+        - "--zap-stacktrace-level=error"
+        {{- end }}
         image: "{{ .Values.images.scaler }}:{{ .Values.images.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.scaler.pullPolicy | default "Always" }}
         name: "{{ .Chart.Name }}-external-scaler"

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -16,6 +16,8 @@ logging:
     # -- Logging time encoding for KEDA http-add-on operator.
     # allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano`
     timeEncoding: rfc3339
+    # -- Display stack traces in the logs
+    stackTracesEnabled: false
 
     kubeRbacProxy:
       # -- Logging level for KEDA http-add-on operator rbac proxy
@@ -31,6 +33,9 @@ logging:
     # -- Logging time encoding for KEDA http-add-on Scaler.
     # allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano`
     timeEncoding: rfc3339
+    # -- Display stack traces in the logs
+    stackTracesEnabled: false
+
   interceptor:
     # -- Logging level for KEDA http-add-on Interceptor.
     # allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string
@@ -41,6 +46,8 @@ logging:
     # -- Logging time encoding for KEDA http-add-on Interceptor.
     # allowed values are `epoch`, `millis`, `nano`, `iso8601`, `rfc3339` or `rfc3339nano`
     timeEncoding: rfc3339
+    # -- Display stack traces in the logs
+    stackTracesEnabled: false
 
 # operator-specific configuration values
 operator:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

This setting is already present in KEDA operator.
