### PR TITLE
fix(KEDA): enable-webhook-patching backward compatability

### DIFF
--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -83,7 +83,9 @@ spec:
           - "--zap-log-level={{ .Values.logging.operator.level }}"
           - "--zap-encoder={{ .Values.logging.operator.format }}"
           - "--zap-time-encoding={{ .Values.logging.operator.timeEncoding }}"
+          {{- if .Values.webhooks.enabled }}
           - "--enable-webhook-patching={{ .Values.webhooks.enabled }}"
+          {{- end }}
           {{- if .Values.logging.operator.stackTracesEnabled }}
           - "--zap-stacktrace-level=error"
           {{- end }}


### PR DESCRIPTION
This commit allows the 2.17 version stream to be backwards compatible
with earlier versions of KEDA.  See 8d75dd0.

Signed-off-by: Eoghan Conlon O'Neill <eoghan.conlononeill@chainguard.dev>
