### PR TITLE
Add release namespace to manager WATCH_NAMESPACE env when watchNamesp…

### DIFF
--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -143,7 +143,7 @@ spec:
             protocol: TCP
           env:
             - name: WATCH_NAMESPACE
-              value: {{ .Values.watchNamespace | quote }}
+              value: {{ .Values.watchNamespace | empty | ternary "" (printf "%s,%s" .Values.watchNamespace .Release.Namespace ) | quote }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
…ace specified

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->
Addresses [issue 748](https://github.com/kedacore/charts/issues/748):

Include the release namespace in the WATCH_NAMESPACE env variable when .Values.watchNamespace is non-empty.

### Checklist

- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
