### PR TITLE
Remove default resources requests and limits - they should be set exp…

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -147,7 +147,7 @@ their default values.
 | `podDisruptionBudget.operator` | object | `{}` | Capability to configure [Pod Disruption Budget] |
 | `podLabels.keda` | object | `{}` | Pod labels for KEDA operator |
 | `podSecurityContext.operator` | object | [See below](#KEDA-is-secure-by-default) | [Pod security context] of the KEDA operator pod |
-| `resources.operator` | object | `{"limits":{"cpu":1,"memory":"1000Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Manage [resource request & limits] of KEDA operator pod |
+| `resources.operator` | object | `{}` | Manage [resource request & limits] of KEDA operator pod |
 | `securityContext.operator` | object | [See below](#KEDA-is-secure-by-default) | [Security context] of the operator container |
 | `serviceAccount.operator.annotations` | object | `{}` | Annotations to add to the service account |
 | `serviceAccount.operator.automountServiceAccountToken` | bool | `true` | Specifies whether a service account should automount API-Credentials |
@@ -181,7 +181,7 @@ their default values.
 | `podDisruptionBudget.metricServer` | object | `{}` | Capability to configure [Pod Disruption Budget] |
 | `podLabels.metricsAdapter` | object | `{}` | Pod labels for KEDA Metrics Adapter |
 | `podSecurityContext.metricServer` | object | [See below](#KEDA-is-secure-by-default) | [Pod security context] of the KEDA metrics apiserver pod |
-| `resources.metricServer` | object | `{"limits":{"cpu":1,"memory":"1000Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Manage [resource request & limits] of KEDA metrics apiserver pod |
+| `resources.metricServer` | object | `{}` | Manage [resource request & limits] of KEDA metrics apiserver pod |
 | `securityContext.metricServer` | object | [See below](#KEDA-is-secure-by-default) | [Security context] of the metricServer container |
 | `service.annotations` | object | `{}` | Annotations to add the KEDA Metric Server service |
 | `service.portHttps` | int | `443` | HTTPS port for KEDA Metric Server service |
@@ -302,7 +302,7 @@ their default values.
 | `podDisruptionBudget.webhooks` | object | `{}` | Capability to configure [Pod Disruption Budget] |
 | `podLabels.webhooks` | object | `{}` | Pod labels for KEDA Admission webhooks |
 | `podSecurityContext.webhooks` | object | [See below](#KEDA-is-secure-by-default) | [Pod security context] of the KEDA admission webhooks |
-| `resources.webhooks` | object | `{"limits":{"cpu":1,"memory":"1000Mi"},"requests":{"cpu":"100m","memory":"100Mi"}}` | Manage [resource request & limits] of KEDA admission webhooks pod |
+| `resources.webhooks` | object | `{}` | Manage [resource request & limits] of KEDA admission webhooks pod |
 | `securityContext.webhooks` | object | [See below](#KEDA-is-secure-by-default) | [Security context] of the admission webhooks container |
 | `serviceAccount.webhooks.annotations` | object | `{}` | Annotations to add to the service account |
 | `serviceAccount.webhooks.automountServiceAccountToken` | bool | `true` | Specifies whether a service account should automount API-Credentials |

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -191,8 +191,6 @@ spec:
           resources:
             {{- if .Values.resources.operator }}
             {{- toYaml .Values.resources.operator | nindent 12 }}
-            {{- else }}
-            {{- toYaml .Values.resources | nindent 12 }}
             {{- end }}
         {{- if .Values.operator.extraContainers }}
         {{- toYaml .Values.operator.extraContainers | nindent 8 }}

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -162,8 +162,6 @@ spec:
           resources:
             {{- if .Values.resources.metricServer }}
             {{- toYaml .Values.resources.metricServer | nindent 12 }}
-            {{- else }}
-            {{- toYaml .Values.resources | nindent 12 }}
             {{- end }}
       volumes:
       - name: certificates

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -143,8 +143,6 @@ spec:
           resources:
             {{- if .Values.resources.webhooks }}
             {{- toYaml .Values.resources.webhooks | nindent 12 }}
-            {{- else }}
-            {{- toYaml .Values.resources | nindent 12 }}
             {{- end }}
       volumes:
       - name: certificates

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -482,29 +482,11 @@ service:
 # and remove/comment the default values
 resources:
   # -- Manage [resource request & limits] of KEDA operator pod
-  operator:
-    limits:
-      cpu: 1
-      memory: 1000Mi
-    requests:
-      cpu: 100m
-      memory: 100Mi
+  operator: {}
   # -- Manage [resource request & limits] of KEDA metrics apiserver pod
-  metricServer:
-    limits:
-      cpu: 1
-      memory: 1000Mi
-    requests:
-      cpu: 100m
-      memory: 100Mi
+  metricServer: {}
   # -- Manage [resource request & limits] of KEDA admission webhooks pod
-  webhooks:
-    limits:
-      cpu: 1
-      memory: 1000Mi
-    requests:
-      cpu: 100m
-      memory: 100Mi
+  webhooks: {}
 # -- Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/))
 nodeSelector: {}
 # -- Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/))


### PR DESCRIPTION
…licitly by the operator

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #

Removes default values for requests and limits, allow operator to define requests and limits when needed. With current implementation it is not possible to remove CPU limits as it will be picked from the default values. 

I'm happy to introduce default values if needed (wouldn't change current behaviour) and use operator values if they're set. 