### PR TITLE
feat(http-add-on): allow setting extra environment variables

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -114,6 +114,7 @@ their default values.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `operator.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
+| `operator.extraEnv` | list | `[]` | Extra environment variables to be added to operator container |
 | `operator.imagePullSecrets` | list | `[]` | The image pull secrets for the operator component |
 | `operator.kubeRbacProxy.resources.limits` | object | `{"cpu":"300m","memory":"200Mi"}` | The CPU/memory resource limit for the operator component's kube rbac proxy |
 | `operator.kubeRbacProxy.resources.requests` | object | `{"cpu":"10m","memory":"20Mi"}` | The CPU/memory resource request for the operator component's kube rbac proxy |
@@ -132,6 +133,7 @@ their default values.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `scaler.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
+| `scaler.extraEnv` | list | `[]` | Extra environment variables to be added to scaler container |
 | `scaler.grpcPort` | int | `9090` | The port for the scaler's gRPC server. This is the server that KEDA will send scaling requests to. |
 | `scaler.imagePullSecrets` | list | `[]` | The image pull secrets for the scaler component |
 | `scaler.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |
@@ -156,6 +158,7 @@ their default values.
 | `interceptor.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
 | `interceptor.endpointsCachePollingIntervalMS` | int | `250` | How often (in milliseconds) the interceptor does a full refresh of its endpoints cache. The interceptor will also use Kubernetes events to stay up-to-date with the endpoints cache changes. This duration is the maximum time it will take to see changes to the endpoints. |
 | `interceptor.expectContinueTimeout` | string | `"1s"` | Special handling for responses with "Expect: 100-continue" response headers. see https://pkg.go.dev/net/http#Transport under the 'ExpectContinueTimeout' field for more details |
+| `interceptor.extraEnv` | list | `[]` | Extra environment variables to be added to interceptor container |
 | `interceptor.forceHTTP2` | bool | `false` | Whether or not the interceptor should force requests to use HTTP/2 |
 | `interceptor.idleConnTimeout` | string | `"90s"` | The timeout after which any idle connection is closed and removed from the interceptor's in-memory connection pool. |
 | `interceptor.imagePullSecrets` | list | `[]` | The image pull secrets for the interceptor component |

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      imagePullSecrets: 
+      imagePullSecrets:
         {{- toYaml .Values.interceptor.imagePullSecrets | nindent 8 }}
       serviceAccountName: {{ .Chart.Name }}-interceptor
       {{- if .Values.podSecurityContext.interceptor }}
@@ -83,6 +83,9 @@ spec:
           value: "{{ .Values.interceptor.tls.key_path }}"
         - name: KEDA_HTTP_PROXY_TLS_PORT
           value: "{{ .Values.interceptor.tls.port }}"
+        {{- end }}
+        {{- if gt (len .Values.interceptor.extraEnv) 0 }}
+        {{- .Values.interceptor.extraEnv | toYaml | nindent 8 }}
         {{- end }}
         ports:
         - containerPort: {{ .Values.interceptor.admin.port }}

--- a/http-add-on/templates/operator/deployment.yaml
+++ b/http-add-on/templates/operator/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      imagePullSecrets: 
+      imagePullSecrets:
         {{- toYaml .Values.operator.imagePullSecrets | nindent 8 }}
       serviceAccountName: {{ .Chart.Name }}
       {{- if .Values.podSecurityContext.operator }}
@@ -76,6 +76,9 @@ spec:
           value: "{{ .Release.Namespace }}"
         - name: KEDA_HTTP_OPERATOR_WATCH_NAMESPACE
           value: "{{ .Values.operator.watchNamespace }}"
+        {{- if gt (len .Values.operator.extraEnv) 0 }}
+        {{- .Values.operator.extraEnv | toYaml | nindent 8 }}
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 8080

--- a/http-add-on/templates/scaler/deployment.yaml
+++ b/http-add-on/templates/scaler/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      imagePullSecrets: 
+      imagePullSecrets:
         {{- toYaml .Values.scaler.imagePullSecrets | nindent 8 }}
       serviceAccountName: {{ .Chart.Name }}-external-scaler
       {{- if .Values.podSecurityContext.scaler }}
@@ -64,6 +64,9 @@ spec:
           value: "{{ default 9091 .Values.interceptor.admin.port }}"
         - name: KEDA_HTTP_SCALER_STREAM_INTERVAL_MS
           value: "{{ .Values.scaler.streamInterval }}"
+        {{- if gt (len .Values.scaler.extraEnv) 0 }}
+        {{ .Values.scaler.extraEnv | toYaml | nindent 8 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.scaler.resources | nindent 10 }}
         livenessProbe:

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -90,6 +90,8 @@ operator:
       requests:
         cpu: 10m
         memory: 20Mi
+  # -- Extra environment variables to be added to operator container
+  extraEnv: []
 
 scaler:
   # -- Number of replicas
@@ -121,6 +123,8 @@ scaler:
       memory: 20Mi
   # -- Annotations to be added to the scaler pods
   podAnnotations: {}
+  # -- Extra environment variables to be added to scaler container
+  extraEnv: []
 
 interceptor:
   # -- The image pull secrets for the interceptor component
@@ -207,6 +211,8 @@ interceptor:
     cert_secret: keda-tls-certs
     # -- Port that the interceptor proxy TLS server should be started on
     port: 8443
+  # -- Extra environment variables to be added to interceptor container
+  extraEnv: []
 
   # configuration of pdb for the interceptor
   pdb:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Allow setting custom environment variables for http-add-on components

Closes #761 

### Checklist

- [ ] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [ ] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [ ] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
