### PR TITLE
feat(keda): Add service trafficDistribution support for K8s 1.31+

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -141,6 +141,7 @@ their default values.
 | `operator.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":20,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |
 | `operator.replicaCount` | int | `1` | Capability to configure the number of replicas for KEDA operator. While you can run more replicas of our operator, only one operator instance will be the leader and serving traffic. You can run multiple replicas, but they will not improve the performance of KEDA, it could only reduce downtime during a failover. Learn more in [our documentation](https://keda.sh/docs/latest/operate/cluster/#high-availability). |
 | `operator.revisionHistoryLimit` | int | `10` | ReplicaSets for this Deployment you want to retain (Default: 10) |
+| `operator.trafficDistribution` | string | `""` | [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) policy for the KEDA operator service |
 | `permissions.operator.restrict.namesAllowList` | list | `[]` | Array of strings denoting what secrets the KEDA operator will be able to read, this takes into account also the configured `watchNamespace`. the default is an empty array -> no restriction on the secret name |
 | `permissions.operator.restrict.secret` | bool | `false` | Restrict Secret Access for KEDA operator if true, KEDA operator will be able to read only secrets in {{ .Release.Namespace }} namespace |
 | `permissions.operator.restrict.serviceAccountTokenCreationRoles` | list | `[]` | Creates roles and rolebindings from namespaced service accounts in the array which allow the KEDA operator to request service account tokens for use with the boundServiceAccountToken trigger source. If the namespace does not exist, this will cause the helm chart installation to fail. |
@@ -188,6 +189,7 @@ their default values.
 | `service.portHttps` | int | `443` | HTTPS port for KEDA Metric Server service |
 | `service.portHttpsTarget` | int | `6443` | HTTPS port for KEDA Metric Server container |
 | `service.type` | string | `"ClusterIP"` | KEDA Metric Server service type |
+| `service.trafficDistribution` | string | `""` | [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) policy for KEDA Metric Server service |
 | `serviceAccount.metricServer.annotations` | object | `{}` | Annotations to add to the service account |
 | `serviceAccount.metricServer.automountServiceAccountToken` | bool | `true` | Specifies whether a service account should automount API-Credentials |
 | `serviceAccount.metricServer.create` | bool | `true` | Specifies whether a service account should be created |
@@ -325,6 +327,7 @@ their default values.
 | `webhooks.revisionHistoryLimit` | int | `10` | ReplicaSets for this Deployment you want to retain (Default: 10) |
 | `webhooks.timeoutSeconds` | int | `10` | Timeout in seconds for KEDA admission webhooks |
 | `webhooks.useHostNetwork` | bool | `false` | Enable webhook to use host network, this is required on EKS with custom CNI |
+| `webhooks.trafficDistribution` | string | `""` | [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) policy for the KEDA admission webhooks service |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`. For example:

--- a/keda/templates/manager/service.yaml
+++ b/keda/templates/manager/service.yaml
@@ -25,6 +25,9 @@ metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.operator.trafficDistribution }}
+  trafficDistribution: {{ .Values.operator.trafficDistribution }}
+  {{- end }}
   ports:
   - name: metricsservice
     port: 9666

--- a/keda/templates/metrics-server/service.yaml
+++ b/keda/templates/metrics-server/service.yaml
@@ -27,6 +27,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.service.trafficDistribution }}
+  {{- end }}
   ports:
   - name: https
     port: {{ .Values.service.portHttps }}

--- a/keda/templates/webhooks/service.yaml
+++ b/keda/templates/webhooks/service.yaml
@@ -26,6 +26,9 @@ metadata:
   name: {{ .Values.webhooks.name }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.webhooks.trafficDistribution }}
+  trafficDistribution: {{ .Values.webhooks.trafficDistribution }}
+  {{- end }}
   ports:
   - name: https
     port: 443

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -119,6 +119,8 @@ operator:
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1
+  # -- [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) policy for the KEDA operator service
+  trafficDistribution: ""
 
 metricsServer:
   # -- ReplicaSets for this Deployment you want to retain (Default: 10)
@@ -207,6 +209,8 @@ webhooks:
 
   # -- [Failure policy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) to use with KEDA admission webhooks
   failurePolicy: Ignore
+  # -- [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) policy for the KEDA admission webhooks service
+  trafficDistribution: ""
 
 upgradeStrategy:
   # -- Capability to configure [Deployment upgrade strategy] for operator
@@ -474,6 +478,8 @@ service:
   portHttpsTarget: 6443
   # -- Annotations to add the KEDA Metric Server service
   annotations: {}
+  # -- [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) policy for KEDA Metric Server service 
+  trafficDistribution: ""
 
 # We provides the default values that we describe in our docs:
 # https://keda.sh/docs/latest/operate/cluster/


### PR DESCRIPTION
Adds kubernetes service [trafficDistribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) configuration to all kyverno services for better performance and data transfer cost optimization.

This PR includes these changes:

- Added trafficDistribution option to values.yaml for all services
- Updated service templates to support the new field
- Added clear documentation with benefits

This gives cluster administrators control over traffic routing for better performance and lower cloud costs.

- Reduces network latency by routing traffic to nearby endpoints
- Cluster administrator can save costs by minimizing cross-zone traffic in cloud environments
- Improves performance in multi-zone clusters

Values example:

```yaml
# keda/values_example.yaml
service:
  trafficDistribution: PreferClose
```

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [ ] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Similar to https://github.com/kyverno/kyverno/pull/13411
