### PR TITLE
Update metrics apiserver to use zap logging flags

### DIFF
--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -122,15 +122,16 @@ spec:
           args:
           - --port={{ .Values.prometheus.metricServer.port }}
           - --secure-port={{ .Values.service.portHttpsTarget }}
-          - --logtostderr=true
-          - --stderrthreshold={{ .Values.logging.metricServer.stderrthreshold }}
           - --disable-compression={{ .Values.metricsServer.disableCompression}}
           - --metrics-service-address={{ .Values.operator.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:9666
           - --client-ca-file={{ .Values.certificates.mountPath }}/ca.crt
           - --tls-cert-file={{ .Values.certificates.mountPath }}/tls.crt
           - --tls-private-key-file={{ .Values.certificates.mountPath }}/tls.key
           - --cert-dir={{ .Values.certificates.mountPath }}
-          - --v={{ .Values.logging.metricServer.level }}
+          - --zap-log-level={{ .Values.logging.metricServer.level }}
+          {{- if .Values.logging.metricServer.format }}
+          - --zap-encoder={{ .Values.logging.metricServer.format }}
+          {{- end }}
           {{- if .Values.profiling.metricsServer.enabled }}
           - "--profiling-bind-address=:{{ .Values.profiling.metricsServer.port }}"
           {{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -388,11 +388,11 @@ logging:
     stackTracesEnabled: false
   metricServer:
     # -- Logging level for Metrics Server.
-    # allowed values: `0` for info, `4` for debug, or an integer value greater than 0, specified as string
-    level: 0
-    # -- Logging stderrthreshold for Metrics Server
-    # allowed values: 'DEBUG','INFO','WARN','ERROR','ALERT','EMERG'
-    stderrthreshold: ERROR
+    # allowed values: `error`, `info`, `debug`
+    level: info
+    # -- Logging format for Metrics Server
+    # allowed values: `json`, `console`
+    format: console
   webhooks:
     # -- Logging level for KEDA Operator.
     # allowed values: `debug`, `info`, `error`, or an integer value greater than 0, specified as string


### PR DESCRIPTION
The KEDA metrics apiserver deprecated klogr flags in favor of zap in
commit 4ee73f064 [1]. The adapter's main.go marks --v, --logtostderr,
and --stderrthreshold as DEPRECATED [2].

KEDA's own deployment.yaml switched to --zap-log-level [3], but the
helm chart still used the deprecated flags.

This change:
- Replaces --v with --zap-log-level
- Removes --logtostderr and --stderrthreshold
- Updates values.yaml to use string log levels (info/debug/error)
  matching other KEDA components for consistency

[1] https://github.com/kedacore/keda/commit/4ee73f064
[2] https://github.com/kedacore/keda/blob/main/cmd/adapter/main.go#L245-L250
[3] https://github.com/kedacore/keda/blob/main/config/metrics-server/deployment.yaml#L60
