### PR TITLE
feat(metrics-server): add `dnsConfig` support

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -87,6 +87,7 @@ their default values.
 | `global.image.registry` | string | `nil` | Global image registry of KEDA components |
 | `grpcTLSCertsSecret` | string | `""` | Set this if you are using an external scaler and want to communicate over TLS (recommended). This variable holds the name of the secret that will be mounted to the /grpccerts path on the Pod |
 | `hashiCorpVaultTLS` | string | `""` | Set this if you are using HashiCorp Vault and want to communicate over TLS (recommended). This variable holds the name of the secret that will be mounted to the /vault path on the Pod |
+| `hostAliases` | list | `[]` | HostAliases for pod networking ([docs](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/)) |
 | `http.keepAlive.enabled` | bool | `true` | Enable HTTP connection keep alive |
 | `http.minTlsVersion` | string | `"TLS12"` | The minimum TLS version to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and this value does not necessarily apply to them) |
 | `http.timeout` | int | `3000` | The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them) |
@@ -116,7 +117,6 @@ their default values.
 | `rbac.scaledRefKinds` | list | `[{"apiGroup":"*","kind":"*"}]` | List of custom resources that support the `scale` subresource and can be referenced by `scaledobject.spec.scaleTargetRef`. The feature needs to be also enabled by `enabledCustomScaledRefKinds`. If left empty, RBAC for `apiGroups: *` and `resources: *, */scale` will be created note: Deployments and StatefulSets are supported out of the box |
 | `securityContext` | object | [See below](#KEDA-is-secure-by-default) | [Security context] for all containers |
 | `tolerations` | list | `[]` | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |
-| `hostAliases` | list | `[]` | HostAliases for pod networking ([docs](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/)) |
 | `watchNamespace` | string | `""` | Defines Kubernetes namespaces to watch to scale their workloads. Default watches all namespaces |
 
 ### Operator
@@ -171,6 +171,7 @@ their default values.
 | `logging.metricServer.stderrthreshold` | string | `"ERROR"` | Logging stderrthreshold for Metrics Server allowed values: 'DEBUG','INFO','WARN','ERROR','ALERT','EMERG' |
 | `metricsServer.affinity` | object | `{}` | [Affinity] for pod scheduling for Metrics API Server. Takes precedence over the `affinity` field |
 | `metricsServer.disableCompression` | bool | `true` | Disable response compression for k8s restAPI in client-go. Disabling compression simply means that turns off the process of making data smaller for K8s restAPI in client-go for faster transmission. |
+| `metricsServer.dnsConfig` | object | `{}` | [DNS config] for KEDA metrics server pod |
 | `metricsServer.dnsPolicy` | string | `"ClusterFirst"` | Defined the DNS policy for the metric server |
 | `metricsServer.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `metricsServer.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -184,6 +184,10 @@ spec:
       {{- toYaml .Values.volumes.metricsApiServer.extraVolumes | nindent 6 }}
       {{- end }}
       dnsPolicy: {{ .Values.metricsServer.dnsPolicy }}
+      {{- if .Values.metricsServer.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.metricsServer.dnsConfig | nindent 8 }}
+      {{- end }}
       hostNetwork: {{ .Values.metricsServer.useHostNetwork }}
       nodeSelector:
         kubernetes.io/os: linux

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -134,6 +134,15 @@ metricsServer:
   # use ClusterFirstWithHostNet if `useHostNetwork: true` https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   # -- Defined the DNS policy for the metric server
   dnsPolicy: ClusterFirst
+  # -- [DNS config] for KEDA metrics server pod
+  dnsConfig: {}
+    # nameservers:
+    #   - 8.8.8.8
+    # searches:
+    #   - metrics.example.com
+    # options:
+    #   - name: ndots
+    #     value: "3"
   # -- Enable metric server to use host network
   useHostNetwork: false
   # -- [Affinity] for pod scheduling for Metrics API Server. Takes precedence over the `affinity` field


### PR DESCRIPTION
### Changes

This PR adds support for configuring DNS settings specifically for the KEDA metrics server pod through the new `metricsServer.dnsConfig` parameter in `values.yaml`.

### Usage Example
```yaml
metricsServer:
  dnsConfig:
    nameservers:
      - "8.8.8.8"
      - "1.1.1.1"
    searches:
      - "metrics.example.com"
    options:
      - name: "ndots"
        value: "3"
```

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
