### PR TITLE
add change in trigger authentication CRD for hashiCorpVault

### DIFF
--- a/keda/templates/crds/crd-triggerauthentications.yaml
+++ b/keda/templates/crds/crd-triggerauthentications.yaml
@@ -458,6 +458,21 @@ spec:
                         type: string
                       token:
                         type: string
+                      tokenSecretRef:
+                        description: AuthSecretTargetRef is used to authenticate using
+                          a reference to a secret
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                          parameter:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        - parameter
+                        type: object
                     type: object
                   mount:
                     type: string


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

What's Changed
Added a new field, tokenSecretRef, to the HashiCorp Vault credentials configuration.

This new field allows users to specify a Kubernetes secret containing the Vault token.

The existing token string field will be used as a fallback if tokenSecretRef is not provided.

Why This Is Important
Previously, the HashiCorp Vault token had to be provided directly as a string in the KEDA configuration. This is not a recommended security practice for production environments, as it can expose sensitive information.

This change introduces a more secure way to manage the token by leveraging Kubernetes secrets. This aligns with best practices for handling credentials within a Kubernetes cluster.

How to Use It
Users can now configure their trigger with either the existing token field or the new tokenSecret field. For example:

```yaml
apiVersion: keda.sh/v1alpha1
kind: TriggerAuthentication
metadata:
  name: {trigger-authentication-mame}
  namespace: default
spec:
  hashiCorpVault:
    address: {hashicorp-vault-address}
    authentication: token
    credential:
      tokenSecretRef: 
        name: {secret-name}
        key: {secret-key}
        parameter: "key"
```
In the example above, secret-name and secret-key point to the secret containing the token.

KEDA core PR change: https://github.com/kedacore/keda/pull/6996

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
