### PR TITLE
chore: Update comments and suggested defaults

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -198,7 +198,7 @@ their default values.
 | `serviceAccount.metricServer.annotations` | object | `{}` | Annotations to add to the service account |
 | `serviceAccount.metricServer.automountServiceAccountToken` | bool | `true` | Specifies whether a service account should automount API-Credentials |
 | `serviceAccount.metricServer.create` | bool | `true` | Specifies whether a service account should be created |
-| `serviceAccount.metricServer.name` | string | `"keda-metrics-server"` | The name of the service account to use. |
+| `serviceAccount.metricServer.name` | string | `"keda-metrics-server"` | The name of the service account to use. If set to empty string `""`, it will fall back to `serviceAccount.operator.name` (default: `keda-operator`). |
 | `topologySpreadConstraints.metricsServer` | list | `[]` | [Pod Topology Constraints] of KEDA metrics apiserver pod |
 | `upgradeStrategy.metricsApiServer` | object | `{}` | Capability to configure [Deployment upgrade strategy] for Metrics Api Server |
 | `volumes.metricsApiServer.extraVolumeMounts` | list | `[]` | Extra volume mounts for metric server deployment |

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -325,6 +325,7 @@ serviceAccount:
     # -- Specifies whether a service account should be created
     create: true
     # -- The name of the service account to use.
+    # If set to empty string "", it will fall back to serviceAccount.operator.name (default: keda-operator)
     name: keda-metrics-server
     # -- Specifies whether a service account should automount API-Credentials
     automountServiceAccountToken: true


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

  Summary

  Updates documentation for serviceAccount.metricServer.name to clarify fallback behavior when set to empty string.

  Changes

  - Updated README.md and values.yaml to document that setting serviceAccount.metricServer.name to "" will fall back to serviceAccount.operator.name
  (default: keda-operator)
  - Improves clarity for users who want to share the same service account between components

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
