### PR TITLE
docs: correct resource name in NOTES.txt

### DIFF
--- a/keda/templates/NOTES.txt
+++ b/keda/templates/NOTES.txt
@@ -30,10 +30,10 @@ Get information about the deployed ScaledObjects:
 Get details about a deployed ScaledObject:
   kubectl describe scaledobject <scaled-object-name> [--namespace <namespace>]
 
-Get information about the deployed ScaledObjects:
+Get information about the deployed TriggerAuthentications:
   kubectl get triggerauthentication [--namespace <namespace>]
 
-Get details about a deployed ScaledObject:
+Get details about a deployed TriggerAuthentication:
   kubectl describe triggerauthentication <trigger-authentication-name> [--namespace <namespace>]
 
 Get an overview of the Horizontal Pod Autoscalers (HPA) that KEDA is using behind the scenes:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Correct ScaledObject to TriggerAuthentication in NOTES.txt

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))

Fixes #

