### PR TITLE
feat(keda): allow users to remove CPU limits

### DIFF
--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -516,7 +516,6 @@ resources:
   # -- Manage [resource request & limits] of KEDA operator pod
   operator:
     limits:
-      cpu: 1
       memory: 1000Mi
     requests:
       cpu: 100m
@@ -524,7 +523,6 @@ resources:
   # -- Manage [resource request & limits] of KEDA metrics apiserver pod
   metricServer:
     limits:
-      cpu: 1
       memory: 1000Mi
     requests:
       cpu: 100m
@@ -532,7 +530,6 @@ resources:
   # -- Manage [resource request & limits] of KEDA admission webhooks pod
   webhooks:
     limits:
-      cpu: 1
       memory: 1000Mi
     requests:
       cpu: 100m


### PR DESCRIPTION
Right now there is no way to remove CPU limits, which can cause excessive CPU throttling and latency. This allows for that. Users can still set the CPU limits but this way they are not forced to set them.

One may consider this a breaking change if the user of the chart has a policy engine installed that requires CPU limits. In that case they would need to add it to the `values.yaml` on their end.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
