### PR TITLE
fix: Chart installation fails when watchNamespace includes the helm release namespace due to duplicate RoleBindings

### DIFF
--- a/keda/templates/manager/clusterrolebindings.yaml
+++ b/keda/templates/manager/clusterrolebindings.yaml
@@ -20,7 +20,7 @@ subjects:
   name: {{ (.Values.serviceAccount.operator).name | default .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
-  {{- $namespaces := append (splitList "," .Values.watchNamespace) .Release.Namespace -}}
+  {{- $namespaces := uniq (append (splitList "," .Values.watchNamespace) .Release.Namespace) -}}
   {{- range $namespaces }}
 ---
 # Role binding for namespace '{{ . }}'


### PR DESCRIPTION
Fix RoleBinding duplication by ensuring the namespace list is unique before generating RoleBindings.

Tribute to @mihirbhagwat0

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

### Fixes
- #744 