### PR TITLE
fix(http-add-on): allow specifying appProtocol for interceptor proxy service

### DIFF
--- a/.github/workflows/ci-http-add-on.yml
+++ b/.github/workflows/ci-http-add-on.yml
@@ -121,6 +121,8 @@ jobs:
           interceptor:
             replicas:
               min: 1
+            proxy:
+              appProtocol: ""
           EOF
 
       - name: Template Helm chart

--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -177,6 +177,7 @@ their default values.
 | `interceptor.pdb.maxUnavailable` | int | `1` | The maximum number of replicas that can be unavailable for the interceptor |
 | `interceptor.pdb.minAvailable` | int | `0` | The minimum number of replicas that should be available for the interceptor |
 | `interceptor.podAnnotations` | object | `{}` | Annotations to be added to the interceptor pods |
+| `interceptor.proxy.appProtocol` | string | `""` | The appProtocol for the interceptor's proxy service ports |
 | `interceptor.proxy.port` | int | `8080` | The port on which the interceptor's proxy service will listen for live HTTP traffic |
 | `interceptor.proxy.service` | string | `"interceptor-proxy"` | The name of the Kubernetes `Service` for the interceptor's proxy service. This is the service that accepts live HTTP traffic. |
 | `interceptor.pullPolicy` | string | `"Always"` | The image pull policy for the interceptor component |

--- a/http-add-on/templates/interceptor/service-proxy.yaml
+++ b/http-add-on/templates/interceptor/service-proxy.yaml
@@ -12,10 +12,16 @@ spec:
   - name: proxy
     port: {{ default 9091 .Values.interceptor.proxy.port }}
     targetPort: proxy
+    {{- if .Values.interceptor.proxy.appProtocol }}
+    appProtocol: {{ .Values.interceptor.proxy.appProtocol }}
+    {{- end }}
   {{- if .Values.interceptor.tls.enabled }}
   - name: proxy-tls
     port: {{ default 8443 .Values.interceptor.tls.port }}
     targetPort: proxy-tls
+    {{- if .Values.interceptor.proxy.appProtocol }}
+    appProtocol: {{ .Values.interceptor.proxy.appProtocol }}
+    {{- end }}
   {{- end }}
   selector:
     app.kubernetes.io/component: interceptor

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -153,6 +153,8 @@ interceptor:
     service: interceptor-proxy
     # -- The port on which the interceptor's proxy service will listen for live HTTP traffic
     port: 8080
+    # -- The appProtocol for the interceptor's proxy service ports
+    appProtocol: ""
   replicas:
     # -- The minimum number of interceptor replicas that should ever be running
     min: 3


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

`.interceptor.proxy.appProtocol` value has been exposed in order to allow custom app protocols such as h2c

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
