### PR TITLE
fix: Correct YAML indentation in opentelemetry.operator

### DIFF
--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -820,8 +820,8 @@ opentelemetry:
     # -- Uri of OpenTelemetry Collector to push telemetry to
     uri: ""
   operator:
-      # -- Enable pushing metrics to an OpenTelemetry Collector for operator
-      enabled: false
+    # -- Enable pushing metrics to an OpenTelemetry Collector for operator
+    enabled: false
 
 certificates:
   # -- Enables the self generation for KEDA TLS certificates inside KEDA operator


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Fix YAML indentation error where opentelemetry.operator was indented 
with 6 spaces instead of 4, causing yamllint validation failures.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

