### PR TITLE
feat(keda): add k8s networkPolicy

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -96,7 +96,8 @@ their default values.
 | `imagePullSecrets` | list | `[]` | Name of secret to use to pull images to use to pull Docker images |
 | `networkPolicy.cilium` | object | `{"operator":{"extraEgressRules":[]}}` | Allow use of extra egress rules for cilium network policies |
 | `networkPolicy.enabled` | bool | `false` | Enable network policies |
-| `networkPolicy.flavor` | string | `"cilium"` | Flavor of the network policies (cilium) |
+| `networkPolicy.flavor` | string | `"cilium"` | Flavor of the network policies (cilium, kubernetes) |
+| `networkPolicy.kubernetes` | object | `{"metricsServer":{"extraEgressRules":[]},"operator":{"extraEgressRules":[]},"webhooks":{"extraEgressRules":[]}}` | Allow use of extra egress rules for kubernetes network policies |
 | `nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |
 | `podIdentity.aws.irsa.audience` | string | `"sts.amazonaws.com"` | Sets the token audience for IRSA. This will be set as an annotation on the KEDA service account. |
 | `podIdentity.aws.irsa.enabled` | bool | `false` | Specifies whether [AWS IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) is to be enabled or not. |

--- a/keda/templates/manager/networkpolicy.yaml
+++ b/keda/templates/manager/networkpolicy.yaml
@@ -1,0 +1,72 @@
+{{- if and .Values.networkPolicy.enabled (eq .Values.networkPolicy.flavor "kubernetes") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.operator.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app: {{ .Values.operator.name }}
+    name: {{ .Values.operator.name }}
+    app.kubernetes.io/name: {{ .Values.operator.name }}
+    {{- include "keda.labels" . | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Values.operator.name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow ingress from any pod in the cluster on the metrics service port (gRPC)
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 9666
+    {{- if .Values.prometheus.operator.enabled }}
+    # Allow ingress from any pod in the cluster on the prometheus metrics port
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.prometheus.operator.port }}
+    {{- end }}
+    {{- if .Values.profiling.operator.enabled }}
+    # Allow ingress from any pod in the cluster on the profiling port
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.profiling.operator.port }}
+    {{- end }}
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow access to Kubernetes API server
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+    # Allow egress to any pod in the cluster for scalers and custom resources
+    - to:
+        - namespaceSelector: {}
+    {{- if .Values.networkPolicy.kubernetes.operator.extraEgressRules }}
+    {{ toYaml .Values.networkPolicy.kubernetes.operator.extraEgressRules | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/keda/templates/metrics-server/networkpolicy.yaml
+++ b/keda/templates/metrics-server/networkpolicy.yaml
@@ -1,0 +1,79 @@
+{{- if and .Values.networkPolicy.enabled (eq .Values.networkPolicy.flavor "kubernetes") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.operator.name }}-metrics-apiserver
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app: {{ .Values.operator.name }}-metrics-apiserver
+    app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver
+    {{- include "keda.labels" . | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Values.operator.name }}-metrics-apiserver
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow ingress from any pod in the cluster on the HTTPS metrics API port
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.portHttpsTarget }}
+    {{- if .Values.prometheus.metricServer.enabled }}
+    # Allow ingress from any pod in the cluster on the prometheus metrics port
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.prometheus.metricServer.port }}
+    {{- end }}
+    {{- if .Values.profiling.metricsServer.enabled }}
+    # Allow ingress from any pod in the cluster on the profiling port
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.profiling.metricsServer.port }}
+    {{- end }}
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow access to Kubernetes API server
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+    # Allow egress to KEDA operator for gRPC metrics service
+    - to:
+        - podSelector:
+            matchLabels:
+              app: {{ .Values.operator.name }}
+      ports:
+        - protocol: TCP
+          port: 9666
+    # Allow egress to any pod in the cluster for metric collection
+    - to:
+        - namespaceSelector: {}
+    {{- if .Values.networkPolicy.kubernetes.metricsServer.extraEgressRules }}
+    {{ toYaml .Values.networkPolicy.kubernetes.metricsServer.extraEgressRules | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/keda/templates/webhooks/networkpolicy.yaml
+++ b/keda/templates/webhooks/networkpolicy.yaml
@@ -1,0 +1,72 @@
+{{- if and .Values.webhooks.enabled .Values.networkPolicy.enabled (eq .Values.networkPolicy.flavor "kubernetes") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.webhooks.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app: {{ .Values.webhooks.name }}
+    name: {{ .Values.webhooks.name }}
+    app.kubernetes.io/name: {{ .Values.webhooks.name }}
+    {{- include "keda.labels" . | indent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Values.webhooks.name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow ingress from Kubernetes API server for admission webhooks
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.webhooks.port | default 9443 }}
+    {{- if .Values.prometheus.webhooks.enabled }}
+    # Allow ingress from any pod in the cluster on the prometheus metrics port
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.prometheus.webhooks.port }}
+    {{- end }}
+    {{- if .Values.profiling.webhooks.enabled }}
+    # Allow ingress from any pod in the cluster on the profiling port
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.profiling.webhooks.port }}
+    {{- end }}
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow access to Kubernetes API server
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+    # Allow egress to any pod in the cluster for validation
+    - to:
+        - namespaceSelector: {}
+    {{- if .Values.networkPolicy.kubernetes.webhooks.extraEgressRules }}
+    {{ toYaml .Values.networkPolicy.kubernetes.webhooks.extraEgressRules | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -68,11 +68,19 @@ imagePullSecrets: []
 networkPolicy:
   # -- Enable network policies
   enabled: false
-  # -- Flavor of the network policies (cilium)
+  # -- Flavor of the network policies (cilium, kubernetes)
   flavor: "cilium"
   # -- Allow use of extra egress rules for cilium network policies
   cilium:
     operator:
+      extraEgressRules: []
+  # -- Allow use of extra egress rules for kubernetes network policies
+  kubernetes:
+    operator:
+      extraEgressRules: []
+    metricsServer:
+      extraEgressRules: []
+    webhooks:
       extraEgressRules: []
 
 operator:
@@ -601,7 +609,6 @@ profiling:
     # -- Expose profiling on a specific port
     port: 8084
 
-
 ## Extra KEDA Operator and Metrics Adapter container arguments
 extraArgs:
   # -- Additional KEDA Operator container arguments
@@ -909,4 +916,3 @@ customManagedBy: ""
 # -- Enable service links in pods. Although enabled, mirroring k8s default, it is highly recommended to disable,
 # due to its legacy status [Legacy container links](https://docs.docker.com/engine/network/links/)
 enableServiceLinks: true
-


### PR DESCRIPTION
Currently the Keda helm chart only supports cilium networkpolicies.
This PR adds support for the natively kubernetes networkPolicy.

As already prepared in the values file we then can use different flavors to tell which networkpolicy should be used.
Kubernetes NetworkPolicies for KEDA components can be enabled via `.Values.networkPolicy.enabled` and `.Values.networkPolicy.flavor` == "kubernetes".

## Configuration

Following network policies are configured:

Component | Ingress Ports | Egress Targets
-- | -- | --
Webhooks | 9443 (admission), optional metrics/profiling | DNS (53), K8s API (443/6443), unrestricted cluster access
Metrics Server | HTTPS metrics API, optional metrics/profiling | DNS (53), K8s API (443/6443), operator gRPC (9666), unrestricted cluster access
Operator | 9666 (gRPC), optional metrics/profiling | DNS (53), K8s API (443/6443), unrestricted cluster access


### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] ~~A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*~~

