### PR TITLE
feat(http-add-on): add TLS skip verify option for interceptor proxy

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -192,6 +192,7 @@ their default values.
 | `interceptor.tls.enabled` | bool | `false` | Whether a TLS server should be started on the interceptor proxy |
 | `interceptor.tls.key_path` | string | `"/certs/tls.key"` | Mount path of the certificate key file to use with the interceptor proxy TLS server |
 | `interceptor.tls.port` | int | `8443` | Port that the interceptor proxy TLS server should be started on |
+| `interceptor.tls.skip_verify` | bool | `false` | Whether to skip TLS verification for the interceptor proxy TLS server |
 | `interceptor.tlsHandshakeTimeout` | string | `"10s"` | The maximum amount of time the interceptor will wait for a TLS handshake. Set to zero to indicate no timeout. |
 | `interceptor.tolerations` | list | `[]` | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |
 | `interceptor.topologySpreadConstraints` | list | `[]` | Topology spread constraints ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)) |

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -83,6 +83,8 @@ spec:
           value: "{{ .Values.interceptor.tls.key_path }}"
         - name: KEDA_HTTP_PROXY_TLS_PORT
           value: "{{ .Values.interceptor.tls.port }}"
+        - name: KEDA_HTTP_PROXY_TLS_SKIP_VERIFY
+          value: "{{ .Values.interceptor.tls.skip_verify }}"
         {{- end }}
         {{- if .Values.profiling.interceptor.enabled }}
         - name: PROFILING_BIND_ADDRESS

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -213,6 +213,8 @@ interceptor:
     cert_secret: keda-tls-certs
     # -- Port that the interceptor proxy TLS server should be started on
     port: 8443
+    # -- Whether to skip TLS verification for the interceptor proxy TLS server
+    skip_verify: false
 
   # configuration of pdb for the interceptor
   pdb:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Add configurable option to skip TLS certificate verification for the interceptor proxy server. This is useful for development environments or when using self-signed certificates.

The option defaults to false to maintain secure behavior by default.

Related HTTP Add-on config [option](https://github.com/kedacore/http-add-on/blob/a832da311c6db5b48c00eab0a1e7d5e814f9deb2/interceptor/config/serving.go#L47).

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
