### PR TITLE
fix(http-add-on): use admin port for interceptor health probes

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -110,11 +110,11 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: proxy
+            port: admin
         readinessProbe:
           httpGet:
             path: /readyz
-            port: proxy
+            port: admin
         resources:
           {{- toYaml .Values.interceptor.resources | nindent 10 }}
         {{- if .Values.securityContext.interceptor }}


### PR DESCRIPTION
The interceptor's /livez and /readyz endpoints have moved from the proxy port to the admin port.

Changes:
- Update livenessProbe port from proxy to admin
- Update readinessProbe port from proxy to admin


### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)

See https://github.com/kedacore/http-add-on/pull/1448
