### PR TITLE
feat(http-add-on): increase connection pool defaults for higher throughput

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -169,7 +169,8 @@ their default values.
 | `interceptor.idleConnTimeout` | string | `"90s"` | The timeout after which any idle connection is closed and removed from the interceptor's in-memory connection pool. |
 | `interceptor.imagePullSecrets` | list | `[]` | The image pull secrets for the interceptor component |
 | `interceptor.keepAlive` | string | `"1s"` | The interceptor's connection keep alive timeout |
-| `interceptor.maxIdleConns` | int | `100` | The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit |
+| `interceptor.maxIdleConns` | int | `1000` | The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit |
+| `interceptor.maxIdleConnsPerHost` | int | `200` | The maximum number of idle connections allowed per host in the interceptor's in-memory connection pool |
 | `interceptor.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |
 | `interceptor.pdb.enabled` | bool | `true` | Whether to install the `PodDisruptionBudget` for the interceptor |
 | `interceptor.pdb.maxUnavailable` | int | `1` | The maximum number of replicas that can be unavailable for the interceptor |

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -68,6 +68,8 @@ spec:
           value: "{{ .Values.interceptor.forceHTTP2 }}"
         - name: KEDA_HTTP_MAX_IDLE_CONNS
           value: "{{ .Values.interceptor.maxIdleConns }}"
+        - name: KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST
+          value: "{{ .Values.interceptor.maxIdleConnsPerHost }}"
         - name: KEDA_HTTP_IDLE_CONN_TIMEOUT
           value: "{{ .Values.interceptor.idleConnTimeout }}"
         - name: KEDA_HTTP_TLS_HANDSHAKE_TIMEOUT

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -174,7 +174,9 @@ interceptor:
   # -- Whether or not the interceptor should force requests to use HTTP/2
   forceHTTP2: false
   # -- The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit
-  maxIdleConns: 100
+  maxIdleConns: 1000
+  # -- The maximum number of idle connections allowed per host in the interceptor's in-memory connection pool
+  maxIdleConnsPerHost: 200
   # -- The timeout after which any idle connection is closed and removed from the interceptor's in-memory connection pool.
   idleConnTimeout: 90s
   # -- The maximum amount of time the interceptor will wait for a TLS handshake. Set to zero to indicate no timeout.


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Increase maxIdleConns from 100 to 1000 and add maxIdleConnsPerHost option with default of 200. These changes align with upstream [PR](https://github.com/kedacore/http-add-on/pull/1469) which identified the previous defaults as a bottleneck under load.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
