### PR TITLE
refactor(http-add-on): remove unused KEDA_HTTP_CURRENT_NAMESPACE env

### DIFF
--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -48,8 +48,6 @@ spec:
         imagePullPolicy: '{{ .Values.interceptor.pullPolicy | default "Always" }}'
         name: "{{ .Chart.Name }}-interceptor"
         env:
-        - name: KEDA_HTTP_CURRENT_NAMESPACE
-          value: "{{ .Release.Namespace }}"
         - name: KEDA_HTTP_PROXY_PORT
           value: "{{ .Values.interceptor.proxy.port }}"
         - name: KEDA_HTTP_ADMIN_PORT


### PR DESCRIPTION
This env var is unused according to https://github.com/kedacore/http-add-on/pull/1484 


### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
