### PR TITLE
chore: Add replicasets to RBAC for informer cache

### DIFF
--- a/keda/templates/manager/clusterrole.yaml
+++ b/keda/templates/manager/clusterrole.yaml
@@ -100,6 +100,7 @@ rules:
   - apps
   resources:
   - deployments
+  - replicasets
   - statefulsets
   verbs:
   - get


### PR DESCRIPTION
Syncs RBAC changes with core: https://github.com/kedacore/keda/pull/7466

This adds list/watch permissions for ReplicaSets to enable the informer cache optimization when targeting ReplicaSets directly with ScaledObjects.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*