### PR TITLE
feat(http-add-on): support TLS version, cipher suite, and curve configuration

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -189,8 +189,12 @@ their default values.
 | `interceptor.tcpConnectTimeout` | string | `"500ms"` | How long the interceptor waits to establish TCP connections with backends before failing a request. |
 | `interceptor.tls.cert_path` | string | `"/certs/tls.crt"` | Mount path of the certificate file to use with the interceptor proxy TLS server |
 | `interceptor.tls.cert_secret` | string | `"keda-tls-certs"` | Name of the Kubernetes secret that contains the certificates to be used with the interceptor proxy TLS server |
+| `interceptor.tls.cipherSuites` | string | `""` | Comma-separated list of supported cipher suites for the interceptor proxy TLS server. Defaults to Go's standard cipher suites. |
+| `interceptor.tls.curvePreferences` | string | `""` | Comma-separated list of supported curve preferences for the interceptor proxy TLS server. Defaults to Go's standard curve selections. |
 | `interceptor.tls.enabled` | bool | `false` | Whether a TLS server should be started on the interceptor proxy |
 | `interceptor.tls.key_path` | string | `"/certs/tls.key"` | Mount path of the certificate key file to use with the interceptor proxy TLS server |
+| `interceptor.tls.maxVersion` | string | `""` | Maximum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard maximum version. |
+| `interceptor.tls.minVersion` | string | `""` | Minimum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard minimum version. |
 | `interceptor.tls.port` | int | `8443` | Port that the interceptor proxy TLS server should be started on |
 | `interceptor.tls.skip_verify` | bool | `false` | Whether to skip TLS verification for the interceptor proxy TLS server |
 | `interceptor.tlsHandshakeTimeout` | string | `"10s"` | The maximum amount of time the interceptor will wait for a TLS handshake. Set to zero to indicate no timeout. |

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -83,6 +83,22 @@ spec:
           value: "{{ .Values.interceptor.tls.port }}"
         - name: KEDA_HTTP_PROXY_TLS_SKIP_VERIFY
           value: "{{ .Values.interceptor.tls.skip_verify }}"
+        {{- if .Values.interceptor.tls.minVersion }}
+        - name: KEDA_HTTP_PROXY_TLS_MIN_VERSION
+          value: "{{ .Values.interceptor.tls.minVersion }}"
+        {{- end }}
+        {{- if .Values.interceptor.tls.maxVersion }}
+        - name: KEDA_HTTP_PROXY_TLS_MAX_VERSION
+          value: "{{ .Values.interceptor.tls.maxVersion }}"
+        {{- end }}
+        {{- if .Values.interceptor.tls.cipherSuites }}
+        - name: KEDA_HTTP_PROXY_TLS_CIPHER_SUITES
+          value: "{{ .Values.interceptor.tls.cipherSuites }}"
+        {{- end }}
+        {{- if .Values.interceptor.tls.curvePreferences }}
+        - name: KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES
+          value: "{{ .Values.interceptor.tls.curvePreferences }}"
+        {{- end }}
         {{- end }}
         {{- if .Values.profiling.interceptor.enabled }}
         - name: PROFILING_BIND_ADDRESS

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -215,6 +215,14 @@ interceptor:
     port: 8443
     # -- Whether to skip TLS verification for the interceptor proxy TLS server
     skip_verify: false
+    # -- Minimum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard minimum version.
+    minVersion: ""
+    # -- Maximum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard maximum version.
+    maxVersion: ""
+    # -- Comma-separated list of supported cipher suites for the interceptor proxy TLS server. Defaults to Go's standard cipher suites.
+    cipherSuites: ""
+    # -- Comma-separated list of supported curve preferences for the interceptor proxy TLS server. Defaults to Go's standard curve selections.
+    curvePreferences: ""
 
   # configuration of pdb for the interceptor
   pdb:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

Add support for configuring the interceptor proxy TLS server with the following options:
- minVersion
- maxVersion
- cipherSuites
- curvePreferences

These values are passed to the interceptor as environment variables (KEDA_HTTP_PROXY_TLS_MIN_VERSION, KEDA_HTTP_PROXY_TLS_CIPHER_SUITES, etc.).
Defaults are inherited from the underlying standard Go library configurations when left unset.

Note: The new TLS options are introduced using camelCase instead of the snake_case format currently used by other TLS options (e.g., cert_path). This is because all other values in the chart adhere to camelCase.
The existing snake_case TLS options will be migrated to camelCase in a subsequent PR.

Ref: kedacore/http-add-on#1530

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #
