### PR TITLE
refactor(http-add-on): rename interceptor TLS values from snake_case to camelCase

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -187,16 +187,16 @@ their default values.
 | `interceptor.responseHeaderTimeout` | string | `"500ms"` | How long the interceptor will wait between forwarding a request to a backend and receiving response headers back before failing the request |
 | `interceptor.scaledObject.pollingInterval` | int | `1` | The interval (in milliseconds) that KEDA should poll the external scaler to fetch scaling metrics about the interceptor |
 | `interceptor.tcpConnectTimeout` | string | `"500ms"` | How long the interceptor waits to establish TCP connections with backends before failing a request. |
-| `interceptor.tls.cert_path` | string | `"/certs/tls.crt"` | Mount path of the certificate file to use with the interceptor proxy TLS server |
-| `interceptor.tls.cert_secret` | string | `"keda-tls-certs"` | Name of the Kubernetes secret that contains the certificates to be used with the interceptor proxy TLS server |
+| `interceptor.tls.certPath` | string | `"/certs/tls.crt"` | Mount path of the certificate file to use with the interceptor proxy TLS server (replaces deprecated `cert_path`) |
+| `interceptor.tls.certSecret` | string | `"keda-tls-certs"` | Name of the Kubernetes secret that contains the certificates to be used with the interceptor proxy TLS server (replaces deprecated `cert_secret`) |
 | `interceptor.tls.cipherSuites` | string | `""` | Comma-separated list of supported cipher suites for the interceptor proxy TLS server. Defaults to Go's standard cipher suites. |
 | `interceptor.tls.curvePreferences` | string | `""` | Comma-separated list of supported curve preferences for the interceptor proxy TLS server. Defaults to Go's standard curve selections. |
 | `interceptor.tls.enabled` | bool | `false` | Whether a TLS server should be started on the interceptor proxy |
-| `interceptor.tls.key_path` | string | `"/certs/tls.key"` | Mount path of the certificate key file to use with the interceptor proxy TLS server |
+| `interceptor.tls.keyPath` | string | `"/certs/tls.key"` | Mount path of the certificate key file to use with the interceptor proxy TLS server (replaces deprecated `key_path`) |
 | `interceptor.tls.maxVersion` | string | `""` | Maximum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard maximum version. |
 | `interceptor.tls.minVersion` | string | `""` | Minimum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard minimum version. |
 | `interceptor.tls.port` | int | `8443` | Port that the interceptor proxy TLS server should be started on |
-| `interceptor.tls.skip_verify` | bool | `false` | Whether to skip TLS verification for the interceptor proxy TLS server |
+| `interceptor.tls.skipVerify` | bool | `false` | Whether to skip TLS verification for the interceptor proxy TLS server (replaces deprecated `skip_verify`) |
 | `interceptor.tlsHandshakeTimeout` | string | `"10s"` | The maximum amount of time the interceptor will wait for a TLS handshake. Set to zero to indicate no timeout. |
 | `interceptor.tolerations` | list | `[]` | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |
 | `interceptor.topologySpreadConstraints` | list | `[]` | Topology spread constraints ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)) |

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -76,13 +76,13 @@ spec:
         - name: KEDA_HTTP_PROXY_TLS_ENABLED
           value: "true"
         - name: KEDA_HTTP_PROXY_TLS_CERT_PATH
-          value: "{{ .Values.interceptor.tls.cert_path }}"
+          value: "{{ if hasKey .Values.interceptor.tls "cert_path" }}{{ .Values.interceptor.tls.cert_path }}{{ else }}{{ .Values.interceptor.tls.certPath }}{{ end }}"
         - name: KEDA_HTTP_PROXY_TLS_KEY_PATH
-          value: "{{ .Values.interceptor.tls.key_path }}"
+          value: "{{ if hasKey .Values.interceptor.tls "key_path" }}{{ .Values.interceptor.tls.key_path }}{{ else }}{{ .Values.interceptor.tls.keyPath }}{{ end }}"
         - name: KEDA_HTTP_PROXY_TLS_PORT
           value: "{{ .Values.interceptor.tls.port }}"
         - name: KEDA_HTTP_PROXY_TLS_SKIP_VERIFY
-          value: "{{ .Values.interceptor.tls.skip_verify }}"
+          value: "{{ if hasKey .Values.interceptor.tls "skip_verify" }}{{ .Values.interceptor.tls.skip_verify }}{{ else }}{{ .Values.interceptor.tls.skipVerify }}{{ end }}"
         {{- if .Values.interceptor.tls.minVersion }}
         - name: KEDA_HTTP_PROXY_TLS_MIN_VERSION
           value: "{{ .Values.interceptor.tls.minVersion }}"
@@ -143,7 +143,7 @@ spec:
       volumes:
         - name: certs
           secret:
-            secretName: {{ .Values.interceptor.tls.cert_secret }}
+            secretName: {{ if hasKey .Values.interceptor.tls "cert_secret" }}{{ .Values.interceptor.tls.cert_secret }}{{ else }}{{ .Values.interceptor.tls.certSecret }}{{ end }}
       {{- end }}
       nodeSelector:
         kubernetes.io/os: linux

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -206,15 +206,19 @@ interceptor:
     # -- Whether a TLS server should be started on the interceptor proxy
     enabled: false
     # -- Mount path of the certificate file to use with the interceptor proxy TLS server
-    cert_path: /certs/tls.crt
+    # (Deprecated: `cert_path` is still supported for backward compatibility)
+    certPath: /certs/tls.crt
     # -- Mount path of the certificate key file to use with the interceptor proxy TLS server
-    key_path: /certs/tls.key
+    # (Deprecated: `key_path` is still supported for backward compatibility)
+    keyPath: /certs/tls.key
     # -- Name of the Kubernetes secret that contains the certificates to be used with the interceptor proxy TLS server
-    cert_secret: keda-tls-certs
+    # (Deprecated: `cert_secret` is still supported for backward compatibility)
+    certSecret: keda-tls-certs
     # -- Port that the interceptor proxy TLS server should be started on
     port: 8443
     # -- Whether to skip TLS verification for the interceptor proxy TLS server
-    skip_verify: false
+    # (Deprecated: `skip_verify` is still supported for backward compatibility)
+    skipVerify: false
     # -- Minimum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard minimum version.
     minVersion: ""
     # -- Maximum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard maximum version.


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Rename cert_path, key_path, cert_secret, and skip_verify to certPath, keyPath, certSecret, and skipVerify in http-add-on chart for consistency with the rest of the chart values.

The old snake_case keys are still supported for backward compatibility via hasKey fallback logic in the deployment template.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Related to #816 
