### PR TITLE
keda-operator: configurable leader election lease resource name

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -141,6 +141,7 @@ their default values.
 | `operator.dnsPolicy` | string | `"ClusterFirst"` | Defined the DNS policy for the operator |
 | `operator.extraContainers` | list | `[]` | Additional containers to run as part of the operator deployment |
 | `operator.extraInitContainers` | list | `[]` | Additional init containers to run as part of the operator deployment |
+| `operator.leaderElectionID` | string | `nil` | When set, overrides the leader election Lease resource name via the `--leader-election-id` flag. When unset (default), the flag is not passed and the operator uses its built-in default (`operator.keda.sh`). Override to allow multiple independent KEDA operator deployments in the same namespace. |
 | `operator.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":25,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `operator.name` | string | `"keda-operator"` | Name of the KEDA operator |
 | `operator.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -79,6 +79,9 @@ spec:
           - "/keda"
           args:
           - "--leader-elect"
+          {{- if .Values.operator.leaderElectionID }}
+          - "--leader-election-id={{ .Values.operator.leaderElectionID }}"
+          {{- end }}
           - "--disable-compression={{ .Values.operator.disableCompression}}"
           - "--zap-log-level={{ .Values.logging.operator.level }}"
           - "--zap-encoder={{ .Values.logging.operator.format }}"

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -96,6 +96,9 @@ operator:
   # --Disable response compression for k8s restAPI in client-go.
   # Disabling compression simply means that turns off the process of making data smaller for K8s restAPI in client-go for faster transmission.
   disableCompression: true
+  # -- Leader election ID (Lease resource name) for the controller manager. Defaults to operator.keda.sh.
+  # Override to allow multiple independent KEDA operator deployments in the same namespace.
+  # leaderElectionID: "operator.keda.sh"
   # -- DNS config for KEDA operator pod
   dnsConfig: {}
   # use ClusterFirstWithHostNet if `useHostNetwork: true` https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy


### PR DESCRIPTION
### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*
  - https://github.com/kedacore/keda/pull/7564