### PR TITLE
Add AWS Parameter Store support to TriggerAuthentication CRDs

### DIFF
--- a/keda/templates/crds/crd-clustertriggerauthentications.yaml
+++ b/keda/templates/crds/crd-clustertriggerauthentications.yaml
@@ -1,15 +1,9 @@
-{{- if .Values.crds.install }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
-    {{- if (or .Values.crds.additionalAnnotations .Values.additionalAnnotations) }}
-    {{- toYaml (merge .Values.crds.additionalAnnotations .Values.additionalAnnotations) | nindent 4 }}
-    {{- end }}
-  labels:
-    app.kubernetes.io/name: {{ .Values.operator.name }}
-    {{- include "keda.crd-labels" . | indent 4 }}
   name: clustertriggerauthentications.keda.sh
 spec:
   group: keda.sh
@@ -73,6 +67,137 @@ spec:
           spec:
             description: TriggerAuthenticationSpec defines the various ways to authenticate
             properties:
+              awsParameterStore:
+                description: AwsParameterStore is used to authenticate using AWS Systems
+                  Manager Parameter Store
+                properties:
+                  credentials:
+                    properties:
+                      accessKey:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      accessSecretKey:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      accessToken:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                    required:
+                    - accessKey
+                    - accessSecretKey
+                    type: object
+                  parameters:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        parameter:
+                          type: string
+                        withDecryption:
+                          type: boolean
+                      required:
+                      - name
+                      - parameter
+                      type: object
+                    minItems: 1
+                    type: array
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  region:
+                    type: string
+                required:
+                - parameters
+                type: object
               awsSecretManager:
                 description: AwsSecretManager is used to authenticate using AwsSecretManager
                 properties:
@@ -202,6 +327,7 @@ spec:
                       - name
                       - parameter
                       type: object
+                    minItems: 1
                     type: array
                 required:
                 - secrets
@@ -306,6 +432,7 @@ spec:
                       - name
                       - parameter
                       type: object
+                    minItems: 1
                     type: array
                   vaultUri:
                     type: string
@@ -445,6 +572,7 @@ spec:
                       - id
                       - parameter
                       type: object
+                    minItems: 1
                     type: array
                 required:
                 - secrets
@@ -458,6 +586,9 @@ spec:
                   authentication:
                     description: VaultAuthentication contains the list of Hashicorp
                       Vault authentication methods
+                    enum:
+                    - token
+                    - kubernetes
                     type: string
                   credential:
                     description: Credential defines the Hashicorp Vault credentials
@@ -506,12 +637,18 @@ spec:
                           type: object
                         type:
                           description: VaultSecretType defines the type of vault secret
+                          enum:
+                          - ""
+                          - secretV2
+                          - secret
+                          - pki
                           type: string
                       required:
                       - key
                       - parameter
                       - path
                       type: object
+                    minItems: 1
                     type: array
                 required:
                 - address
@@ -593,4 +730,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end -}}

--- a/keda/templates/crds/crd-triggerauthentications.yaml
+++ b/keda/templates/crds/crd-triggerauthentications.yaml
@@ -1,15 +1,9 @@
-{{- if .Values.crds.install }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
-    {{- if (or .Values.crds.additionalAnnotations .Values.additionalAnnotations) }}
-    {{- toYaml (merge .Values.crds.additionalAnnotations .Values.additionalAnnotations) | nindent 4 }}
-    {{- end }}
-  labels:
-    app.kubernetes.io/name: {{ .Values.operator.name }}
-    {{- include "keda.crd-labels" . | indent 4 }}
   name: triggerauthentications.keda.sh
 spec:
   group: keda.sh
@@ -69,6 +63,137 @@ spec:
           spec:
             description: TriggerAuthenticationSpec defines the various ways to authenticate
             properties:
+              awsParameterStore:
+                description: AwsParameterStore is used to authenticate using AWS Systems
+                  Manager Parameter Store
+                properties:
+                  credentials:
+                    properties:
+                      accessKey:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      accessSecretKey:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                      accessToken:
+                        properties:
+                          valueFrom:
+                            properties:
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - key
+                                - name
+                                type: object
+                            required:
+                            - secretKeyRef
+                            type: object
+                        required:
+                        - valueFrom
+                        type: object
+                    required:
+                    - accessKey
+                    - accessSecretKey
+                    type: object
+                  parameters:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        parameter:
+                          type: string
+                        withDecryption:
+                          type: boolean
+                      required:
+                      - name
+                      - parameter
+                      type: object
+                    minItems: 1
+                    type: array
+                  podIdentity:
+                    description: |-
+                      AuthPodIdentity allows users to select the platform native identity
+                      mechanism
+                    properties:
+                      identityAuthorityHost:
+                        description: Set identityAuthorityHost to override the default
+                          Azure authority host. If this is set, then the IdentityTenantID
+                          must also be set
+                        type: string
+                      identityId:
+                        type: string
+                      identityOwner:
+                        description: IdentityOwner configures which identity has to
+                          be used during auto discovery, keda or the scaled workload.
+                          Mutually exclusive with roleArn
+                        enum:
+                        - keda
+                        - workload
+                        type: string
+                      identityTenantId:
+                        description: Set identityTenantId to override the default
+                          Azure tenant id. If this is set, then the IdentityID must
+                          also be set
+                        type: string
+                      provider:
+                        description: PodIdentityProvider contains the list of providers
+                        enum:
+                        - azure-workload
+                        - gcp
+                        - aws
+                        - aws-eks
+                        - none
+                        type: string
+                      roleArn:
+                        description: RoleArn sets the AWS RoleArn to be used. Mutually
+                          exclusive with IdentityOwner
+                        type: string
+                    required:
+                    - provider
+                    type: object
+                  region:
+                    type: string
+                required:
+                - parameters
+                type: object
               awsSecretManager:
                 description: AwsSecretManager is used to authenticate using AwsSecretManager
                 properties:
@@ -198,6 +323,7 @@ spec:
                       - name
                       - parameter
                       type: object
+                    minItems: 1
                     type: array
                 required:
                 - secrets
@@ -302,6 +428,7 @@ spec:
                       - name
                       - parameter
                       type: object
+                    minItems: 1
                     type: array
                   vaultUri:
                     type: string
@@ -441,6 +568,7 @@ spec:
                       - id
                       - parameter
                       type: object
+                    minItems: 1
                     type: array
                 required:
                 - secrets
@@ -454,6 +582,9 @@ spec:
                   authentication:
                     description: VaultAuthentication contains the list of Hashicorp
                       Vault authentication methods
+                    enum:
+                    - token
+                    - kubernetes
                     type: string
                   credential:
                     description: Credential defines the Hashicorp Vault credentials
@@ -502,12 +633,18 @@ spec:
                           type: object
                         type:
                           description: VaultSecretType defines the type of vault secret
+                          enum:
+                          - ""
+                          - secretV2
+                          - secret
+                          - pki
                           type: string
                       required:
                       - key
                       - parameter
                       - path
                       type: object
+                    minItems: 1
                     type: array
                 required:
                 - address
@@ -589,4 +726,3 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end -}}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Updates TriggerAuthentication and ClusterTriggerAuthentication CRDs to include the new `awsParameterStore` field. Enables scalers to authenticate and retrieve secrets from AWS Systems Manager Parameter Store.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Relates to https://github.com/kedacore/keda/pull/7572
