### PR TITLE
feat(http-add-on): ClusterRole and ClusterRoleBinding use release name

### DIFF
--- a/http-add-on/templates/interceptor/rbac.yml
+++ b/http-add-on/templates/interceptor/rbac.yml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: interceptor
     app.kubernetes.io/name: http-add-on
     {{- include "keda-http-add-on.labels" . | indent 4 }}
-  name: {{ .Chart.Name }}-interceptor
+  name: {{ .Release.Name }}-interceptor
 rules:
 - apiGroups:
   - discovery.k8s.io
@@ -40,15 +40,15 @@ metadata:
     httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
-    name: {{ .Chart.Name }}-interceptor
+    name: {{ .Release.Name }}-interceptor
     app.kubernetes.io/component: interceptor
     app.kubernetes.io/name: http-add-on
     {{- include "keda-http-add-on.labels" . | indent 4 }}
-  name: {{ .Chart.Name }}-interceptor
+  name: {{ .Release.Name }}-interceptor
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Chart.Name }}-interceptor
+  name: {{ .Release.Name }}-interceptor
 subjects:
 - kind: ServiceAccount
   name: {{ .Chart.Name }}-interceptor

--- a/http-add-on/templates/operator/rbac.yml
+++ b/http-add-on/templates/operator/rbac.yml
@@ -36,11 +36,11 @@ metadata:
     httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
-    name: {{ .Chart.Name }}-role
+    name: {{ .Release.Name }}-role
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: http-add-on
     {{- include "keda-http-add-on.labels" . | indent 4 }}
-  name: {{ .Chart.Name }}-role
+  name: {{ .Release.Name }}-role
 rules:
 - apiGroups:
   - http.keda.sh
@@ -91,11 +91,11 @@ metadata:
     httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
-    name: {{ .Chart.Name }}-metrics-reader
+    name: {{ .Release.Name }}-metrics-reader
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: http-add-on
     {{- include "keda-http-add-on.labels" . | indent 4 }}
-  name: {{ .Chart.Name }}-metrics-reader
+  name: {{ .Release.Name }}-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics
@@ -131,15 +131,15 @@ metadata:
     httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
-    name: {{ .Chart.Name }}-rolebinding
+    name: {{ .Release.Name }}-rolebinding
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: http-add-on
     {{- include "keda-http-add-on.labels" . | indent 4 }}
-  name: {{ .Chart.Name }}-rolebinding
+  name: {{ .Release.Name }}-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Chart.Name }}-role
+  name: {{ .Release.Name }}-role
 subjects:
 - kind: ServiceAccount
   name: {{ .Chart.Name }}
@@ -153,11 +153,11 @@ metadata:
     httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
-    name: {{ .Chart.Name }}-auth-delegator
+    name: {{ .Release.Name }}-auth-delegator
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: http-add-on
     {{- include "keda-http-add-on.labels" . | indent 4 }}
-  name: {{ .Chart.Name }}-auth-delegator
+  name: {{ .Release.Name }}-auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/http-add-on/templates/rbac-aggregateclusterroles.yaml
+++ b/http-add-on/templates/rbac-aggregateclusterroles.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Chart.Name }}-edit
+  name: {{ .Release.Name }}-edit
   labels:
     app.kubernetes.io/name: http-add-on
     {{- include "keda-http-add-on.labels" . | indent 4 }}
@@ -27,7 +27,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Chart.Name }}-view
+  name: {{ .Release.Name }}-view
   labels:
     app.kubernetes.io/name: http-add-on
     rbac.authorization.k8s.io/aggregate-to-admin: "true"

--- a/http-add-on/templates/scaler/rbac.yml
+++ b/http-add-on/templates/scaler/rbac.yml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: scaler
     app.kubernetes.io/name: http-add-on
     {{- include "keda-http-add-on.labels" . | indent 4 }}
-  name: {{ .Chart.Name }}-external-scaler
+  name: {{ .Release.Name }}-external-scaler
 rules:
 - apiGroups:
   - discovery.k8s.io
@@ -32,15 +32,15 @@ metadata:
     httpscaledobjects.http.keda.sh/version: {{ .Values.images.tag | default .Chart.AppVersion }}
     keda.sh/addon: {{ .Chart.Name }}
     app: {{ .Chart.Name }}
-    name: {{ .Chart.Name }}-external-scaler
+    name: {{ .Release.Name }}-external-scaler
     app.kubernetes.io/component: scaler
     app.kubernetes.io/name: http-add-on
     {{- include "keda-http-add-on.labels" . | indent 4 }}
-  name: {{ .Chart.Name }}-external-scaler
+  name: {{ .Release.Name }}-external-scaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Chart.Name }}-external-scaler
+  name: {{ .Release.Name }}-external-scaler
 subjects:
 - kind: ServiceAccount
   name: {{ .Chart.Name }}-external-scaler


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->


http-add-on's ClusterRole and ClusterRoleBinding use `.Release.Name` instead of `.Chart.Name`

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #843
