### PR TITLE
chore: update http-add-on to v0.14.0

### DIFF
--- a/http-add-on/Chart.yaml
+++ b/http-add-on/Chart.yaml
@@ -11,12 +11,12 @@ kubeVersion: ">=v1.23.0-0"
 # to the chart and its templates, including the app version. This is incremented at chart release time and does not need
 # to be included in any PRs to main.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.13.0
+appVersion: 0.14.0
 home: https://github.com/kedacore/http-add-on
 sources:
   - https://github.com/kedacore/http-add-on

--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -46,7 +46,7 @@ We are a Cloud Native Computing Foundation (CNCF) graduated project.
 helm repo add kedacore https://kedacore.github.io/charts
 helm repo update
 
-helm install http-add-on kedacore/keda-add-ons-http --create-namespace --namespace keda --version 0.13.0
+helm install http-add-on kedacore/keda-add-ons-http --create-namespace --namespace keda --version 0.14.0
 ```
 
 ## Introduction
@@ -163,12 +163,9 @@ their default values.
 | `interceptor.admin.port` | int | `9090` | The port for the interceptor's admin server to run on |
 | `interceptor.admin.service` | string | `"interceptor-admin"` | The name of the Kubernetes `Service` for the interceptor's admin service |
 | `interceptor.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
-| `interceptor.expectContinueTimeout` | string | `"1s"` | Special handling for responses with "Expect: 100-continue" response headers. see https://pkg.go.dev/net/http#Transport under the 'ExpectContinueTimeout' field for more details |
 | `interceptor.extraEnvs` | object | `{}` | Extra environment variables to set (key-value map with "ENV name":"value") |
 | `interceptor.forceHTTP2` | bool | `false` | Whether or not the interceptor should force requests to use HTTP/2 |
-| `interceptor.idleConnTimeout` | string | `"90s"` | The timeout after which any idle connection is closed and removed from the interceptor's in-memory connection pool. |
 | `interceptor.imagePullSecrets` | list | `[]` | The image pull secrets for the interceptor component |
-| `interceptor.keepAlive` | string | `"1s"` | The interceptor's connection keep alive timeout |
 | `interceptor.maxIdleConns` | int | `1000` | The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit |
 | `interceptor.maxIdleConnsPerHost` | int | `200` | The maximum number of idle connections allowed per host in the interceptor's in-memory connection pool |
 | `interceptor.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |
@@ -180,14 +177,16 @@ their default values.
 | `interceptor.proxy.port` | int | `8080` | The port on which the interceptor's proxy service will listen for live HTTP traffic |
 | `interceptor.proxy.service` | string | `"interceptor-proxy"` | The name of the Kubernetes `Service` for the interceptor's proxy service. This is the service that accepts live HTTP traffic. |
 | `interceptor.pullPolicy` | string | `"Always"` | The image pull policy for the interceptor component |
+| `interceptor.readinessTimeout` | string | `""` | Time to wait for the backend to become ready, e.g. scale from zero. Replaces the deprecated `interceptor.replicas.waitTimeout` fallback. When unset, uses the code default (disabled). |
 | `interceptor.replicas.max` | int | `50` | The maximum number of interceptor replicas that should ever be running |
 | `interceptor.replicas.min` | int | `3` | The minimum number of interceptor replicas that should ever be running |
-| `interceptor.replicas.waitTimeout` | string | `"20s"` | The maximum time the interceptor should wait for an HTTP request to reach a backend before it is considered a failure |
+| `interceptor.replicas.waitTimeout` | string | `""` | Deprecated fallback for `interceptor.readinessTimeout`. Supported for backward compatibility during upgrades; use `interceptor.readinessTimeout` instead. |
+| `interceptor.requestTimeout` | string | `""` | Total request lifecycle deadline. When unset, uses the code default (disabled). |
 | `interceptor.resources.limits` | object | `{"cpu":0.5,"memory":"64Mi"}` | The CPU/memory resource limit for the interceptor component |
 | `interceptor.resources.requests` | object | `{"cpu":"250m","memory":"20Mi"}` | The CPU/memory resource request for the interceptor component |
-| `interceptor.responseHeaderTimeout` | string | `"500ms"` | How long the interceptor will wait between forwarding a request to a backend and receiving response headers back before failing the request |
+| `interceptor.responseHeaderTimeout` | string | `""` | Time to wait for response headers from the backend. When unset, uses the code default (300s). |
 | `interceptor.scaledObject.pollingInterval` | int | `1` | The interval (in milliseconds) that KEDA should poll the external scaler to fetch scaling metrics about the interceptor |
-| `interceptor.tcpConnectTimeout` | string | `"500ms"` | How long the interceptor waits to establish TCP connections with backends before failing a request. |
+| `interceptor.tcpConnectTimeout` | string | `""` | Per-attempt TCP dial timeout. When unset, uses the code default (500ms). |
 | `interceptor.tls.appProtocol` | string | `""` | The appProtocol for the interceptor's TLS proxy service port |
 | `interceptor.tls.certPath` | string | `"/certs/tls.crt"` | Mount path of the certificate file to use with the interceptor proxy TLS server. Also accepts the deprecated `cert_path`. |
 | `interceptor.tls.certSecret` | string | `"keda-tls-certs"` | Name of the Kubernetes secret that contains the certificates to be used with the interceptor proxy TLS server. Also accepts the deprecated `cert_secret`. |
@@ -199,7 +198,6 @@ their default values.
 | `interceptor.tls.minVersion` | string | `""` | Minimum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard minimum version. |
 | `interceptor.tls.port` | int | `8443` | Port that the interceptor proxy TLS server should be started on |
 | `interceptor.tls.skipVerify` | bool | `false` | Whether to skip TLS verification for the interceptor proxy TLS server. Also accepts the deprecated `skip_verify`. |
-| `interceptor.tlsHandshakeTimeout` | string | `"10s"` | The maximum amount of time the interceptor will wait for a TLS handshake. Set to zero to indicate no timeout. |
 | `interceptor.tolerations` | list | `[]` | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |
 | `interceptor.topologySpreadConstraints` | list | `[]` | Topology spread constraints ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)) |
 

--- a/http-add-on/templates/NOTES.txt
+++ b/http-add-on/templates/NOTES.txt
@@ -1,0 +1,16 @@
+{{/* TODO(v1): remove all deprecation warnings below */}}
+{{- if .Values.interceptor.replicas.waitTimeout }}
+WARNING: interceptor.replicas.waitTimeout is deprecated, use interceptor.readinessTimeout instead.
+{{- end }}
+{{- if .Values.interceptor.keepAlive }}
+WARNING: interceptor.keepAlive has been removed. TCP keepalive now uses Go's default (15s).
+{{- end }}
+{{- if .Values.interceptor.idleConnTimeout }}
+WARNING: interceptor.idleConnTimeout has been removed. Uses Go's default (90s).
+{{- end }}
+{{- if .Values.interceptor.tlsHandshakeTimeout }}
+WARNING: interceptor.tlsHandshakeTimeout has been removed. Uses Go's default (10s).
+{{- end }}
+{{- if .Values.interceptor.expectContinueTimeout }}
+WARNING: interceptor.expectContinueTimeout has been removed. Uses Go's default (1s).
+{{- end }}

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -52,26 +52,29 @@ spec:
           value: "{{ .Values.interceptor.proxy.port }}"
         - name: KEDA_HTTP_ADMIN_PORT
           value: "{{ .Values.interceptor.admin.port }}"
+        {{- with .Values.interceptor.requestTimeout }}
+        - name: KEDA_HTTP_REQUEST_TIMEOUT
+          value: "{{ . }}"
+        {{- end }}
+        {{- with .Values.interceptor.responseHeaderTimeout }}
+        - name: KEDA_HTTP_RESPONSE_HEADER_TIMEOUT
+          value: "{{ . }}"
+        {{- end }}
+        {{/* TODO(v1): remove waitTimeout fallback */}}
+        {{- with (.Values.interceptor.readinessTimeout | default .Values.interceptor.replicas.waitTimeout) }}
+        - name: KEDA_HTTP_READINESS_TIMEOUT
+          value: "{{ . }}"
+        {{- end }}
+        {{- with .Values.interceptor.tcpConnectTimeout }}
         - name: KEDA_HTTP_CONNECT_TIMEOUT
-          value: "{{ .Values.interceptor.tcpConnectTimeout }}"
-        - name: KEDA_HTTP_KEEP_ALIVE
-          value: "{{ .Values.interceptor.keepAlive }}"
-        - name: KEDA_RESPONSE_HEADER_TIMEOUT
-          value: "{{ .Values.interceptor.responseHeaderTimeout }}"
-        - name: KEDA_CONDITION_WAIT_TIMEOUT
-          value: "{{ .Values.interceptor.replicas.waitTimeout }}"
+          value: "{{ . }}"
+        {{- end }}
         - name: KEDA_HTTP_FORCE_HTTP2
           value: "{{ .Values.interceptor.forceHTTP2 }}"
         - name: KEDA_HTTP_MAX_IDLE_CONNS
           value: "{{ .Values.interceptor.maxIdleConns }}"
         - name: KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST
           value: "{{ .Values.interceptor.maxIdleConnsPerHost }}"
-        - name: KEDA_HTTP_IDLE_CONN_TIMEOUT
-          value: "{{ .Values.interceptor.idleConnTimeout }}"
-        - name: KEDA_HTTP_TLS_HANDSHAKE_TIMEOUT
-          value: "{{ .Values.interceptor.tlsHandshakeTimeout }}"
-        - name: KEDA_HTTP_EXPECT_CONTINUE_TIMEOUT
-          value: "{{ .Values.interceptor.expectContinueTimeout }}"
         {{- if .Values.interceptor.tls.enabled }}
         - name: KEDA_HTTP_PROXY_TLS_ENABLED
           value: "true"

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -156,8 +156,8 @@ interceptor:
     min: 3
     # -- The maximum number of interceptor replicas that should ever be running
     max: 50
-    # -- The maximum time the interceptor should wait for an HTTP request to reach a backend before it is considered a failure
-    waitTimeout: 20s
+    # -- Deprecated fallback for `interceptor.readinessTimeout`. Supported for backward compatibility during upgrades; use `interceptor.readinessTimeout` instead.
+    waitTimeout: ""
 
   # configuration for the ScaledObject resource for the
   # interceptor
@@ -165,24 +165,20 @@ interceptor:
     # -- The interval (in milliseconds) that KEDA should poll the external scaler to fetch scaling metrics about the interceptor
     pollingInterval: 1
 
-  # -- How long the interceptor waits to establish TCP connections with backends before failing a request.
-  tcpConnectTimeout: 500ms
-  # -- The interceptor's connection keep alive timeout
-  keepAlive: 1s
-  # -- How long the interceptor will wait between forwarding a request to a backend and receiving response headers back before failing the request
-  responseHeaderTimeout: 500ms
+  # -- Total request lifecycle deadline. When unset, uses the code default (disabled).
+  requestTimeout: ""
+  # -- Time to wait for response headers from the backend. When unset, uses the code default (300s).
+  responseHeaderTimeout: ""
+  # -- Time to wait for the backend to become ready, e.g. scale from zero. Replaces the deprecated `interceptor.replicas.waitTimeout` fallback. When unset, uses the code default (disabled).
+  readinessTimeout: ""
+  # -- Per-attempt TCP dial timeout. When unset, uses the code default (500ms).
+  tcpConnectTimeout: ""
   # -- Whether or not the interceptor should force requests to use HTTP/2
   forceHTTP2: false
   # -- The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit
   maxIdleConns: 1000
   # -- The maximum number of idle connections allowed per host in the interceptor's in-memory connection pool
   maxIdleConnsPerHost: 200
-  # -- The timeout after which any idle connection is closed and removed from the interceptor's in-memory connection pool.
-  idleConnTimeout: 90s
-  # -- The maximum amount of time the interceptor will wait for a TLS handshake. Set to zero to indicate no timeout.
-  tlsHandshakeTimeout: 10s
-  # -- Special handling for responses with "Expect: 100-continue" response headers. see https://pkg.go.dev/net/http#Transport under the 'ExpectContinueTimeout' field for more details
-  expectContinueTimeout: 1s
   # -- Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/))
   nodeSelector: {}
   # -- Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/))


### PR DESCRIPTION

- Bump versions to `0.14.0`
- Align interceptor timeout env vars with v0.14.0 changes: remove deprecated vars (`KEDA_HTTP_KEEP_ALIVE`, `KEDA_CONDITION_WAIT_TIMEOUT`, `KEDA_RESPONSE_HEADER_TIMEOUT`, `KEDA_HTTP_IDLE_CONN_TIMEOUT`, `KEDA_HTTP_TLS_HANDSHAKE_TIMEOUT`, `KEDA_HTTP_EXPECT_CONTINUE_TIMEOUT`), add new vars (`KEDA_HTTP_REQUEST_TIMEOUT`, `KEDA_HTTP_RESPONSE_HEADER_TIMEOUT`, `KEDA_HTTP_READINESS_TIMEOUT`)
- Add NOTES.txt with deprecation warnings for removed Helm values
- Regenerate README with helm-docs

Related: https://github.com/kedacore/http-add-on/releases/tag/v0.14.0

### Example of NOTES output when using deprecated values
```
NOTES:
WARNING: interceptor.replicas.waitTimeout is deprecated, use interceptor.readinessTimeout instead.
WARNING: interceptor.keepAlive has been removed. TCP keepalive now uses Go's default (15s).
WARNING: interceptor.idleConnTimeout has been removed. Uses Go's default (90s).
WARNING: interceptor.tlsHandshakeTimeout has been removed. Uses Go's default (10s).
WARNING: interceptor.expectContinueTimeout has been removed. Uses Go's default (1s).

```


### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)

See https://github.com/kedacore/http-add-on/issues/1606
