### PR TITLE
fix(http-add-on): rename KEDAHTTP_OPERATOR_EXTERNAL_SCALER_* env vars to KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_*

### DIFF
--- a/http-add-on/templates/operator/deployment.yaml
+++ b/http-add-on/templates/operator/deployment.yaml
@@ -64,9 +64,9 @@ spec:
         imagePullPolicy: '{{ .Values.operator.pullPolicy | default "Always" }}'
         name: "{{ .Chart.Name }}-operator"
         env:
-        - name: KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE
+        - name: KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_SERVICE
           value: "{{ .Chart.Name }}-{{ .Values.scaler.service }}"
-        - name: KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT
+        - name: KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_PORT
           value: "{{ default 9090 .Values.scaler.grpcPort }}"
         - name: KEDA_HTTP_OPERATOR_NAMESPACE
           value: "{{ .Release.Namespace }}"


### PR DESCRIPTION
Rename `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE` and `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT` environment variables to `KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_SERVICE` and `KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_PORT`, fixing the missing underscore after `KEDA` to be consistent with all other `KEDA_HTTP_OPERATOR_*` variables.

Aligns the Helm chart with [kedacore/http-add-on#1623](https://github.com/kedacore/http-add-on/pull/1623).

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #