### PR TITLE
RBAC change from "events" to "events.k8s.io"

### DIFF
--- a/keda/templates/manager/clusterrole.yaml
+++ b/keda/templates/manager/clusterrole.yaml
@@ -33,7 +33,7 @@ rules:
   - create
 {{- end }}
 - apiGroups:
-  - ""
+  - events.k8s.io
   resources:
   - events
   verbs:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

RBAC change from "events" to "events.k8s.io" because update to k8s 0.35 deps

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Relates: https://github.com/kedacore/keda/pull/7781
