### PR TITLE
feat(http-add-on): remove KEDA_HTTP_FORCE_HTTP2 env var

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -164,7 +164,6 @@ their default values.
 | `interceptor.admin.service` | string | `"interceptor-admin"` | The name of the Kubernetes `Service` for the interceptor's admin service |
 | `interceptor.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
 | `interceptor.extraEnvs` | object | `{}` | Extra environment variables to set (key-value map with "ENV name":"value") |
-| `interceptor.forceHTTP2` | bool | `false` | Whether or not the interceptor should force requests to use HTTP/2 |
 | `interceptor.imagePullSecrets` | list | `[]` | The image pull secrets for the interceptor component |
 | `interceptor.maxIdleConns` | int | `1000` | The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit |
 | `interceptor.maxIdleConnsPerHost` | int | `200` | The maximum number of idle connections allowed per host in the interceptor's in-memory connection pool |

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -69,8 +69,6 @@ spec:
         - name: KEDA_HTTP_CONNECT_TIMEOUT
           value: "{{ . }}"
         {{- end }}
-        - name: KEDA_HTTP_FORCE_HTTP2
-          value: "{{ .Values.interceptor.forceHTTP2 }}"
         - name: KEDA_HTTP_MAX_IDLE_CONNS
           value: "{{ .Values.interceptor.maxIdleConns }}"
         - name: KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -173,8 +173,6 @@ interceptor:
   readinessTimeout: ""
   # -- Per-attempt TCP dial timeout. When unset, uses the code default (500ms).
   tcpConnectTimeout: ""
-  # -- Whether or not the interceptor should force requests to use HTTP/2
-  forceHTTP2: false
   # -- The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit
   maxIdleConns: 1000
   # -- The maximum number of idle connections allowed per host in the interceptor's in-memory connection pool


### PR DESCRIPTION
The interceptor now automatically detects and forwards HTTP/2 and gRPC traffic based on the inbound request protocol, making this manual toggle unnecessary.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)

Depends on https://github.com/kedacore/http-add-on/pull/1658