### PR TITLE
feat(keda): controller sharding by label selectors

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -123,6 +123,8 @@ their default values.
 | `service.minTlsVersion` | string | `"TLS13"` | The minimum TLS version to use when KEDA components listen via TLS-enabled services (gRPC & Webhook). |
 | `service.tlsCipherList` | string | `""` | The list of cipher suites to use when KEDA components listen via TLS-enabled services. When left empty or unset, the TLS implementation will provide a default list of cipher suites which are believed to be secure. |
 | `tolerations` | list | `[]` | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |
+| `watchLabelSelector` | string | `""` | Restricts the operator to reconcile only ScaledObjects and ScaledJobs (and their derived HorizontalPodAutoscalers) matching the given Kubernetes label selector. Default (empty) means no label-based filtering. Mirrors `watchNamespace`, but filters by label instead of by namespace. Examples: "environment=production", "tier in (gold,silver)", "!canary" |
+| `watchLabelSelectorForTriggerauth` | string | `""` | Restricts the operator to reconcile only TriggerAuthentications and ClusterTriggerAuthentications matching the given Kubernetes label selector. Default (empty) means no label-based filtering. Decoupled from `watchLabelSelector` so a single cluster-scoped ClusterTriggerAuthentication can be shared across operators scoped to different label selectors. |
 | `watchNamespace` | string | `""` | Defines Kubernetes namespaces to watch to scale their workloads. Default watches all namespaces |
 
 ### Operator

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -150,6 +150,10 @@ spec:
           env:
             - name: WATCH_NAMESPACE
               value: {{ .Values.watchNamespace | quote }}
+            - name: WATCH_LABEL_SELECTOR
+              value: {{ .Values.watchLabelSelector | quote }}
+            - name: WATCH_LABEL_SELECTOR_FOR_TRIGGERAUTH
+              value: {{ .Values.watchLabelSelectorForTriggerauth | quote }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -62,6 +62,18 @@ crds:
 # -- Defines Kubernetes namespaces to watch to scale their workloads. Default watches all namespaces
 watchNamespace: ""
 
+# -- Restricts the operator to reconcile only ScaledObjects and ScaledJobs (and their derived
+# HorizontalPodAutoscalers) matching the given Kubernetes label selector. Default (empty) means
+# no label-based filtering. Mirrors `watchNamespace`, but filters by label instead of by namespace.
+# Examples: "environment=production", "tier in (gold,silver)", "!canary"
+watchLabelSelector: ""
+
+# -- Restricts the operator to reconcile only TriggerAuthentications and ClusterTriggerAuthentications
+# matching the given Kubernetes label selector. Default (empty) means no label-based filtering.
+# Decoupled from `watchLabelSelector` so a single cluster-scoped ClusterTriggerAuthentication can be
+# shared across operators scoped to different label selectors.
+watchLabelSelectorForTriggerauth: ""
+
 # -- Name of secret to use to pull images to use to pull Docker images
 imagePullSecrets: []
 


### PR DESCRIPTION
Exposes the `WATCH_LABEL_SELECTOR` env var on the KEDA operator Deployment, via a new `watchLabelSelector` chart value.

Mirrors the existing `watchNamespace` value, but filters reconciled objects by label instead of by namespace. Empty (default) means no label-based filtering, which preserves the current behaviour.

Backs the KEDA core PR kedacore/keda#7816 which adds the env var to the operator.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Relates to kedacore/keda#7816
