### PR TITLE
Simplifying if/else to with, including copilot instructions (nindent fix follow-up)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,36 @@
+# Copilot Instructions
+
+## Code review
+
+### Helm template: consistent fallback patterns
+
+When a template value has a component-level override falling back to a global default
+(e.g. `tolerations`, `affinity`, `nodeSelector`), prefer the `with`/`default` pattern
+over `if`/`else if`:
+
+```yaml
+# Preferred — single toYaml, nindent only once
+tolerations:
+{{- with .Values.component.tolerations | default .Values.tolerations }}
+  {{- toYaml . | nindent 8 }}
+{{- end }}
+
+# Avoid — duplicated toYaml, easy to forget nindent on one branch
+{{- if .Values.component.tolerations }}
+tolerations:
+  {{- toYaml .Values.component.tolerations | nindent 8 }}
+{{- else if .Values.tolerations }}
+tolerations:
+  {{- toYaml .Values.tolerations | nindent 8 }}
+{{- end }}
+```
+
+The `if`/`else` variant requires repeating `toYaml | nindent` in every branch, and a
+missing `nindent` produces invalid YAML that only surfaces at deploy time. The
+`with`/`default` variant has a single output point, eliminating that class of bug.
+
+### Helm template: nindent on every toYaml
+
+Every `toYaml` that emits block content (lists or maps) must be piped through `nindent`
+(or `indent`). Flag any `toYaml` that is missing indentation control — the resulting
+YAML will almost certainly be invalid.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,8 +10,8 @@ over `if`/`else if`:
 
 ```yaml
 # Preferred — single toYaml, nindent only once
-tolerations:
 {{- with .Values.component.tolerations | default .Values.tolerations }}
+tolerations:
   {{- toYaml . | nindent 8 }}
 {{- end }}
 

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -240,12 +240,9 @@ spec:
       {{- if .Values.podIdentity.gcp.enabled }}
         iam.gke.io/gke-metadata-server-enabled: "true"
       {{- end }}
-      {{- if .Values.operator.affinity }}
+      {{- with .Values.operator.affinity | default .Values.affinity }}
       affinity:
-        {{- toYaml .Values.operator.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      affinity:
-        {{- toYaml .Values.affinity | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.topologySpreadConstraints.operator }}
       topologySpreadConstraints:

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -251,12 +251,9 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.operator.tolerations }}
+      {{- with .Values.operator.tolerations | default .Values.tolerations }}
       tolerations:
-        {{- toYaml .Values.operator.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      tolerations:
-        {{- toYaml .Values.tolerations | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $dnsConfig := .Values.operator.dnsConfig | default .Values.global.dnsConfig }}
       {{- if $dnsConfig }}

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -216,11 +216,8 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.metricsServer.tolerations }}
+      {{- with .Values.metricsServer.tolerations | default .Values.tolerations }}
       tolerations:
-        {{- toYaml .Values.metricsServer.tolerations | nindent 8 }}
-      {{- else if .Values.tolerations }}
-      tolerations:
-        {{- toYaml .Values.tolerations | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -205,12 +205,9 @@ spec:
       {{- with .Values.metricsServer.nodeSelector | default .Values.nodeSelector }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.metricsServer.affinity }}
+      {{- with .Values.metricsServer.affinity | default .Values.affinity }}
       affinity:
-        {{- toYaml .Values.metricsServer.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      affinity:
-        {{- toYaml .Values.affinity | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.topologySpreadConstraints.metricsServer}}
       topologySpreadConstraints:

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -171,12 +171,9 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.webhooks.tolerations }}
+      {{- with .Values.webhooks.tolerations | default .Values.tolerations }}
       tolerations:
-        {{- toYaml .Values.webhooks.tolerations | nindent 8 }}
-      {{ else if .Values.tolerations }}
-      tolerations:
-        {{- toYaml .Values.tolerations | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- $dnsConfig := .Values.webhooks.dnsConfig | default .Values.global.dnsConfig }}
       {{- if $dnsConfig }}

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -160,12 +160,9 @@ spec:
       {{- with .Values.webhooks.nodeSelector | default .Values.nodeSelector }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.webhooks.affinity }}
+      {{- with .Values.webhooks.affinity | default .Values.affinity }}
       affinity:
-        {{- toYaml .Values.webhooks.affinity | nindent 8 }}
-      {{- else if .Values.affinity }}
-      affinity:
-        {{- toYaml .Values.affinity | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.topologySpreadConstraints.webhooks }}
       topologySpreadConstraints:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Follow up of #868 

Bug already fixed in #862 , but couldn't but notice the wildly inconsistent use of `if/else` and `with`. 

While at it, implemented the simpler change, and a copilot review instruction that aims to improve consistency in the long run.

Worth noting that the `test-values.yaml` generated in [workflow](https://github.com/kedacore/charts/blob/main/.github/workflows/ci-core.yml#L88), does not include tolerations, so by the looks of it there's quite some template code not covered by CI.

Lemme know if I can help in any way in improving that.

(Note to self: Should re-check for dupes when starting, getting distracted, and resuming a day later)

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #868
