### PR TITLE
feat(http-add-on): add scaler observability configuration

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -142,6 +142,9 @@ their default values.
 | `scaler.grpcPort` | int | `9090` | The port for the scaler's gRPC server. This is the server that KEDA will send scaling requests to. |
 | `scaler.imagePullSecrets` | list | `[]` | The image pull secrets for the scaler component |
 | `scaler.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |
+| `scaler.metrics.otlp.enabled` | bool | `false` | Enable the OTLP HTTP metrics exporter for the scaler |
+| `scaler.metrics.prometheus.enabled` | bool | `true` | Enable the Prometheus metrics exporter for the scaler |
+| `scaler.metrics.prometheus.port` | int | `2223` | Port for the scaler's Prometheus `/metrics` endpoint |
 | `scaler.pendingRequestsInterceptor` | int | `200` | The number of "target requests" that the external scaler will report to KEDA for the interceptor's scaling metrics. See the [KEDA external scaler documentation](https://keda.sh/docs/2.4/concepts/external-scalers/) for details on target requests. |
 | `scaler.podAnnotations` | object | `{}` | Annotations to be added to the scaler pods |
 | `scaler.pullPolicy` | string | `"Always"` | The image pull policy for the scaler component |
@@ -154,6 +157,8 @@ their default values.
 | `scaler.streamInterval` | int | `200` | Interval in ms for communicating IsActive to KEDA |
 | `scaler.tolerations` | list | `[]` | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |
 | `scaler.topologySpreadConstraints` | list | `[]` | Topology spread constraints ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)) |
+| `scaler.tracing.enabled` | bool | `false` | Enable OTLP tracing for the scaler |
+| `scaler.tracing.protocol` | string | `"console"` | Tracing exporter protocol (`console`, `http/protobuf`, or `grpc`) |
 
 ### Interceptor
 

--- a/http-add-on/templates/scaler/deployment.yaml
+++ b/http-add-on/templates/scaler/deployment.yaml
@@ -51,6 +51,10 @@ spec:
         ports:
         - containerPort: {{ .Values.scaler.grpcPort }}
           name: grpc
+        {{- if .Values.scaler.metrics.prometheus.enabled }}
+        - containerPort: {{ .Values.scaler.metrics.prometheus.port }}
+          name: metrics
+        {{- end }}
         env:
         - name: KEDA_HTTP_SCALER_TARGET_ADMIN_DEPLOYMENT
           value: "{{ .Chart.Name }}-interceptor"
@@ -64,6 +68,16 @@ spec:
           value: "{{ default 9091 .Values.interceptor.admin.port }}"
         - name: KEDA_HTTP_SCALER_STREAM_INTERVAL_MS
           value: "{{ .Values.scaler.streamInterval }}"
+        - name: OTEL_PROM_EXPORTER_ENABLED
+          value: "{{ .Values.scaler.metrics.prometheus.enabled }}"
+        - name: OTEL_PROM_EXPORTER_PORT
+          value: "{{ .Values.scaler.metrics.prometheus.port }}"
+        - name: OTEL_EXPORTER_OTLP_METRICS_ENABLED
+          value: "{{ .Values.scaler.metrics.otlp.enabled }}"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENABLED
+          value: "{{ .Values.scaler.tracing.enabled }}"
+        - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+          value: "{{ .Values.scaler.tracing.protocol }}"
         {{- if .Values.profiling.scaler.enabled }}
         - name: PROFILING_BIND_ADDRESS
           value: "127.0.0.1:{{ .Values.profiling.scaler.port }}"

--- a/http-add-on/templates/scaler/service.yaml
+++ b/http-add-on/templates/scaler/service.yaml
@@ -12,6 +12,11 @@ spec:
   - name: grpc
     port: {{ default 9090 .Values.scaler.grpcPort }}
     targetPort: grpc
+  {{- if .Values.scaler.metrics.prometheus.enabled }}
+  - name: metrics
+    port: {{ .Values.scaler.metrics.prometheus.port }}
+    targetPort: metrics
+  {{- end }}
   selector:
     app.kubernetes.io/component: scaler
     app.kubernetes.io/name: http-add-on

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -124,6 +124,22 @@ scaler:
   # -- Annotations to be added to the scaler pods
   podAnnotations: {}
 
+  # OpenTelemetry observability configuration for the scaler
+  metrics:
+    prometheus:
+      # -- Enable the Prometheus metrics exporter for the scaler
+      enabled: true
+      # -- Port for the scaler's Prometheus `/metrics` endpoint
+      port: 2223
+    otlp:
+      # -- Enable the OTLP HTTP metrics exporter for the scaler
+      enabled: false
+  tracing:
+    # -- Enable OTLP tracing for the scaler
+    enabled: false
+    # -- Tracing exporter protocol (`console`, `http/protobuf`, or `grpc`)
+    protocol: "console"
+
 interceptor:
   # -- Extra environment variables to set (key-value map with "ENV name":"value")
   extraEnvs: {}


### PR DESCRIPTION
Add OpenTelemetry metrics and tracing configuration to the scaler
deployment template, matching the upstream change in
kedacore/http-add-on#1634.

**New `values.yaml` settings under `scaler`:**

| Value | Default | Description |
|---|---|---|
| `otelPrometheusExporter.enabled` | `true` | Enable the Prometheus `/metrics` endpoint |
| `otelPrometheusExporter.port` | `2223` | Port for the Prometheus metrics endpoint |
| `otelHTTPExporter.enabled` | `false` | Enable OTLP HTTP metrics export |
| `tracing.enabled` | `false` | Enable OTLP tracing |
| `tracing.exporter` | `"console"` | Tracing exporter protocol (`console`, `http/protobuf`, or `grpc`) |

**Deployment template changes:**
- Conditional `metrics` container port (2223) when Prometheus exporter is enabled
- Five OTEL environment variables wired from the new values

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Relates to kedacore/http-add-on#1634