### PR TITLE
Add optional hostUsers field to the KEDA pods

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -144,7 +144,7 @@ their default values.
 | `operator.dnsPolicy` | string | `"ClusterFirst"` | Defined the DNS policy for the operator |
 | `operator.extraContainers` | list | `[]` | Additional containers to run as part of the operator deployment |
 | `operator.extraInitContainers` | list | `[]` | Additional init containers to run as part of the operator deployment |
-| `operator.hostUsers` | bool | `nil` | Sets `hostUsers` on the KEDA operator pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace. |
+| `operator.hostUsers` | bool | `nil` | Sets `hostUsers` on the KEDA operator pod. Leave unset to preserve the cluster default, `false` to run the pod in its own [user namespace](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/), or `true` to explicitly use the host user namespace. |
 | `operator.leaderElectionID` | string | `nil` | When set, overrides the leader election Lease resource name via the `--leader-election-id` flag. When unset (default), the flag is not passed and the operator uses its built-in default (`operator.keda.sh`). Override to allow multiple independent KEDA operator deployments in the same namespace. |
 | `operator.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":25,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `operator.name` | string | `"keda-operator"` | Name of the KEDA operator |
@@ -191,7 +191,7 @@ their default values.
 | `metricsServer.dnsConfig` | object | `{}` | DNS config for KEDA metrics server pod |
 | `metricsServer.dnsPolicy` | string | `"ClusterFirst"` | Defined the DNS policy for the metric server |
 | `metricsServer.enabled` | bool | `true` | Enable KEDA metrics server and external metrics API resources. |
-| `metricsServer.hostUsers` | bool | `nil` | Sets `hostUsers` on the KEDA metrics server pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace. |
+| `metricsServer.hostUsers` | bool | `nil` | Sets `hostUsers` on the KEDA metrics server pod. Leave unset to preserve the cluster default, `false` to run the pod in its own [user namespace](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/), or `true` to explicitly use the host user namespace. |
 | `metricsServer.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `metricsServer.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |
 | `metricsServer.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |
@@ -340,7 +340,7 @@ their default values.
 | `webhooks.enabled` | bool | `true` |  |
 | `webhooks.failurePolicy` | string | `"Ignore"` | [Failure policy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) to use with KEDA admission webhooks |
 | `webhooks.healthProbePort` | int | `8081` | Port number to use for KEDA admission webhooks health probe |
-| `webhooks.hostUsers` | bool | `nil` | Sets `hostUsers` on the KEDA admission webhooks pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace. |
+| `webhooks.hostUsers` | bool | `nil` | Sets `hostUsers` on the KEDA admission webhooks pod. Leave unset to preserve the cluster default, `false` to run the pod in its own [user namespace](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/), or `true` to explicitly use the host user namespace. |
 | `webhooks.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":25,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for admission webhooks ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `webhooks.name` | string | `"keda-admission-webhooks"` | Name of the KEDA admission webhooks |
 | `webhooks.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |

--- a/keda/README.md
+++ b/keda/README.md
@@ -144,6 +144,7 @@ their default values.
 | `operator.dnsPolicy` | string | `"ClusterFirst"` | Defined the DNS policy for the operator |
 | `operator.extraContainers` | list | `[]` | Additional containers to run as part of the operator deployment |
 | `operator.extraInitContainers` | list | `[]` | Additional init containers to run as part of the operator deployment |
+| `operator.hostUsers` | bool | `nil` | Sets `hostUsers` on the KEDA operator pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace. |
 | `operator.leaderElectionID` | string | `nil` | When set, overrides the leader election Lease resource name via the `--leader-election-id` flag. When unset (default), the flag is not passed and the operator uses its built-in default (`operator.keda.sh`). Override to allow multiple independent KEDA operator deployments in the same namespace. |
 | `operator.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":25,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for operator ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `operator.name` | string | `"keda-operator"` | Name of the KEDA operator |
@@ -190,6 +191,7 @@ their default values.
 | `metricsServer.dnsConfig` | object | `{}` | DNS config for KEDA metrics server pod |
 | `metricsServer.dnsPolicy` | string | `"ClusterFirst"` | Defined the DNS policy for the metric server |
 | `metricsServer.enabled` | bool | `true` | Enable KEDA metrics server and external metrics API resources. |
+| `metricsServer.hostUsers` | bool | `nil` | Sets `hostUsers` on the KEDA metrics server pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace. |
 | `metricsServer.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `metricsServer.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |
 | `metricsServer.readinessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":3,"successThreshold":1,"timeoutSeconds":1}` | Readiness probes for Metrics API Server ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)) |
@@ -338,6 +340,7 @@ their default values.
 | `webhooks.enabled` | bool | `true` |  |
 | `webhooks.failurePolicy` | string | `"Ignore"` | [Failure policy](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) to use with KEDA admission webhooks |
 | `webhooks.healthProbePort` | int | `8081` | Port number to use for KEDA admission webhooks health probe |
+| `webhooks.hostUsers` | bool | `nil` | Sets `hostUsers` on the KEDA admission webhooks pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace. |
 | `webhooks.livenessProbe` | object | `{"failureThreshold":3,"initialDelaySeconds":25,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness probes for admission webhooks ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) |
 | `webhooks.name` | string | `"keda-admission-webhooks"` | Name of the KEDA admission webhooks |
 | `webhooks.nodeSelector` | object | `{}` | Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)) |

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -259,6 +259,9 @@ spec:
       {{- end }}
       dnsPolicy: {{ .Values.operator.dnsPolicy }}
       hostNetwork: {{ .Values.operator.useHostNetwork }}
+      {{- if not (kindIs "invalid" .Values.operator.hostUsers) }}
+      hostUsers: {{ .Values.operator.hostUsers }}
+      {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -200,6 +200,9 @@ spec:
       {{- end }}
       dnsPolicy: {{ .Values.metricsServer.dnsPolicy }}
       hostNetwork: {{ .Values.metricsServer.useHostNetwork }}
+      {{- if not (kindIs "invalid" .Values.metricsServer.hostUsers) }}
+      hostUsers: {{ .Values.metricsServer.hostUsers }}
+      {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
       {{- with .Values.metricsServer.nodeSelector | default .Values.nodeSelector }}

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -155,6 +155,9 @@ spec:
       {{- toYaml .Values.volumes.webhooks.extraVolumes | nindent 6 }}
       {{- end }}
       hostNetwork: {{ .Values.webhooks.useHostNetwork }}
+      {{- if not (kindIs "invalid" .Values.webhooks.hostUsers) }}
+      hostUsers: {{ .Values.webhooks.hostUsers }}
+      {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
       {{- with .Values.webhooks.nodeSelector | default .Values.nodeSelector }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -106,7 +106,7 @@ operator:
   dnsPolicy: ClusterFirst
   # -- Enable operator to use host network
   useHostNetwork: false
-  # -- (bool) Sets `hostUsers` on the KEDA operator pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace.
+  # -- (bool) Sets `hostUsers` on the KEDA operator pod. Leave unset to preserve the cluster default, `false` to run the pod in its own [user namespace](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/), or `true` to explicitly use the host user namespace.
   hostUsers:
   # -- [Affinity] for pod scheduling for KEDA operator. Takes precedence over the `affinity` field
   affinity: {}
@@ -176,7 +176,7 @@ metricsServer:
   dnsConfig: {}
   # -- Enable metric server to use host network
   useHostNetwork: false
-  # -- (bool) Sets `hostUsers` on the KEDA metrics server pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace.
+  # -- (bool) Sets `hostUsers` on the KEDA metrics server pod. Leave unset to preserve the cluster default, `false` to run the pod in its own [user namespace](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/), or `true` to explicitly use the host user namespace.
   hostUsers:
   # -- [Affinity] for pod scheduling for Metrics API Server. Takes precedence over the `affinity` field
   affinity: {}
@@ -235,7 +235,7 @@ webhooks:
   timeoutSeconds: 10
   # -- Enable webhook to use host network, this is required on EKS with custom CNI
   useHostNetwork: false
-  # -- (bool) Sets `hostUsers` on the KEDA admission webhooks pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace.
+  # -- (bool) Sets `hostUsers` on the KEDA admission webhooks pod. Leave unset to preserve the cluster default, `false` to run the pod in its own [user namespace](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/), or `true` to explicitly use the host user namespace.
   hostUsers:
   # -- Name of the KEDA admission webhooks
   name: keda-admission-webhooks

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -106,6 +106,8 @@ operator:
   dnsPolicy: ClusterFirst
   # -- Enable operator to use host network
   useHostNetwork: false
+  # -- (bool) Sets `hostUsers` on the KEDA operator pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace.
+  hostUsers:
   # -- [Affinity] for pod scheduling for KEDA operator. Takes precedence over the `affinity` field
   affinity: {}
     # podAntiAffinity:
@@ -174,6 +176,8 @@ metricsServer:
   dnsConfig: {}
   # -- Enable metric server to use host network
   useHostNetwork: false
+  # -- (bool) Sets `hostUsers` on the KEDA metrics server pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace.
+  hostUsers:
   # -- [Affinity] for pod scheduling for Metrics API Server. Takes precedence over the `affinity` field
   affinity: {}
     # podAntiAffinity:
@@ -231,6 +235,8 @@ webhooks:
   timeoutSeconds: 10
   # -- Enable webhook to use host network, this is required on EKS with custom CNI
   useHostNetwork: false
+  # -- (bool) Sets `hostUsers` on the KEDA admission webhooks pod to opt into [user namespaces](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/). Leave unset to preserve the cluster default; set to `false` to run the pod in its own user namespace.
+  hostUsers:
   # -- Name of the KEDA admission webhooks
   name: keda-admission-webhooks
   # -- ReplicaSets for this Deployment you want to retain (Default: 10)


### PR DESCRIPTION
Adds an opt-in `hostUsers` field to the operator, metrics server and admission
webhooks pods so KEDA's components can run in their own user namespace
(graduated in Kubernetes 1.36). Mirrors the existing `useHostNetwork` toggle.

Unset by default, so existing renders are byte-identical; setting
`operator.hostUsers` / `metricsServer.hostUsers` / `webhooks.hostUsers` to
`true` or `false` emits the field on the matching pod only.

### Validation (local)

- `helm lint keda`: 0 failed
- `helm template`: default omits the field (no diff for current users); set to
  `false`/`true` renders it on the correct pod(s) only
- `helm install` on a kind v1.34 cluster with `hostUsers=true`: operator, metrics
  server and webhooks pods all Running, field present on the live pod specs
- apiserver accepts `hostUsers=false` (deployment + new ReplicaSet created);
  running a pod with `false` additionally needs the node to support user namespaces

### Checklist

- [x] I have verified that my change is according to the deprecations & breaking changes policy
- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] README is updated with new configuration values
- [x] A PR is opened to update KEDA core — not applicable (chart-only opt-in value, default unset = no change to the static core manifests)

Fixes #879

