### PR TITLE
feat: support per-component Deployment labels and annotations

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -130,8 +130,8 @@ their default values.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `certificates.operator` | string | `nil` |  |
-| `deploymentAnnotations.keda` | object | `{}` | Deployment annotations for KEDA operator |
-| `deploymentLabels.keda` | object | `{}` | Deployment labels for KEDA operator |
+| `deploymentAnnotations.keda` | object | `{}` | Deployment annotations for KEDA operator. Rendered through `tpl` |
+| `deploymentLabels.keda` | object | `{}` | Deployment labels for KEDA operator. Rendered through `tpl` |
 | `extraArgs.keda` | object | `{}` | Additional KEDA Operator container arguments |
 | `image.keda.registry` | string | `"ghcr.io"` | Image registry of KEDA operator |
 | `image.keda.repository` | string | `"kedacore/keda"` | Image name of KEDA operator |
@@ -178,8 +178,8 @@ their default values.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `deploymentAnnotations.metricsAdapter` | object | `{}` | Deployment annotations for KEDA Metrics Adapter |
-| `deploymentLabels.metricsAdapter` | object | `{}` | Deployment labels for KEDA Metrics Adapter |
+| `deploymentAnnotations.metricsAdapter` | object | `{}` | Deployment annotations for KEDA Metrics Adapter. Rendered through `tpl` |
+| `deploymentLabels.metricsAdapter` | object | `{}` | Deployment labels for KEDA Metrics Adapter. Rendered through `tpl` |
 | `extraArgs.metricsAdapter` | object | `{}` | Additional Metrics Adapter container arguments |
 | `image.metricsApiServer.registry` | string | `"ghcr.io"` | Image registry of KEDA Metrics API Server |
 | `image.metricsApiServer.repository` | string | `"kedacore/keda-metrics-apiserver"` | Image name of KEDA Metrics API Server |
@@ -317,8 +317,8 @@ their default values.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `deploymentAnnotations.webhooks` | object | `{}` | Deployment annotations for KEDA Admission webhooks |
-| `deploymentLabels.webhooks` | object | `{}` | Deployment labels for KEDA Admission webhooks |
+| `deploymentAnnotations.webhooks` | object | `{}` | Deployment annotations for KEDA Admission webhooks. Rendered through `tpl` |
+| `deploymentLabels.webhooks` | object | `{}` | Deployment labels for KEDA Admission webhooks. Rendered through `tpl` |
 | `image.webhooks.registry` | string | `"ghcr.io"` | Image registry of KEDA admission-webhooks |
 | `image.webhooks.repository` | string | `"kedacore/keda-admission-webhooks"` | Image name of KEDA admission-webhooks |
 | `image.webhooks.tag` | string | `""` | Image tag of KEDA admission-webhooks . Optional, given app version of Helm chart is used by default |

--- a/keda/README.md
+++ b/keda/README.md
@@ -130,6 +130,8 @@ their default values.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `certificates.operator` | string | `nil` |  |
+| `deploymentAnnotations.keda` | object | `{}` | Deployment annotations for KEDA operator |
+| `deploymentLabels.keda` | object | `{}` | Deployment labels for KEDA operator |
 | `extraArgs.keda` | object | `{}` | Additional KEDA Operator container arguments |
 | `image.keda.registry` | string | `"ghcr.io"` | Image registry of KEDA operator |
 | `image.keda.repository` | string | `"kedacore/keda"` | Image name of KEDA operator |
@@ -176,6 +178,8 @@ their default values.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| `deploymentAnnotations.metricsAdapter` | object | `{}` | Deployment annotations for KEDA Metrics Adapter |
+| `deploymentLabels.metricsAdapter` | object | `{}` | Deployment labels for KEDA Metrics Adapter |
 | `extraArgs.metricsAdapter` | object | `{}` | Additional Metrics Adapter container arguments |
 | `image.metricsApiServer.registry` | string | `"ghcr.io"` | Image registry of KEDA Metrics API Server |
 | `image.metricsApiServer.repository` | string | `"kedacore/keda-metrics-apiserver"` | Image name of KEDA Metrics API Server |
@@ -313,6 +317,8 @@ their default values.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| `deploymentAnnotations.webhooks` | object | `{}` | Deployment annotations for KEDA Admission webhooks |
+| `deploymentLabels.webhooks` | object | `{}` | Deployment labels for KEDA Admission webhooks |
 | `image.webhooks.registry` | string | `"ghcr.io"` | Image registry of KEDA admission-webhooks |
 | `image.webhooks.repository` | string | `"kedacore/keda-admission-webhooks"` | Image name of KEDA admission-webhooks |
 | `image.webhooks.tag` | string | `""` | Image tag of KEDA admission-webhooks . Optional, given app version of Helm chart is used by default |

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with .Values.deploymentAnnotations.keda }}
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
   {{- end }}
   labels:
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}
     {{- with .Values.deploymentLabels.keda }}
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.operator.revisionHistoryLimit}}

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -3,15 +3,23 @@ kind: Deployment
 metadata:
   name: {{ .Values.operator.name }}
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.additionalAnnotations }}
+  {{- if or .Values.additionalAnnotations .Values.deploymentAnnotations.keda }}
   annotations:
+    {{- with .Values.additionalAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.deploymentAnnotations.keda }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
   labels:
     app: {{ .Values.operator.name }}
     name: {{ .Values.operator.name }}
     app.kubernetes.io/name: {{ .Values.operator.name }}
     {{- include "keda.labels" . | indent 4 }}
+    {{- with .Values.deploymentLabels.keda }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.operator.revisionHistoryLimit}}
   replicas: {{ .Values.operator.replicaCount}}

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -4,14 +4,22 @@ kind: Deployment
 metadata:
   name: {{ .Values.operator.name }}-metrics-apiserver
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.additionalAnnotations }}
+  {{- if or .Values.additionalAnnotations .Values.deploymentAnnotations.metricsAdapter }}
   annotations:
+    {{- with .Values.additionalAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.deploymentAnnotations.metricsAdapter }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
   labels:
     app: {{ .Values.operator.name }}-metrics-apiserver
     app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver
     {{- include "keda.labels" . | indent 4 }}
+    {{- with .Values.deploymentLabels.metricsAdapter }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.metricsServer.revisionHistoryLimit}}
   replicas: {{ .Values.metricsServer.replicaCount }}

--- a/keda/templates/metrics-server/deployment.yaml
+++ b/keda/templates/metrics-server/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with .Values.deploymentAnnotations.metricsAdapter }}
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
   {{- end }}
   labels:
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/name: {{ .Values.operator.name }}-metrics-apiserver
     {{- include "keda.labels" . | indent 4 }}
     {{- with .Values.deploymentLabels.metricsAdapter }}
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.metricsServer.revisionHistoryLimit}}

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- with .Values.deploymentAnnotations.webhooks }}
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
   {{- end }}
   labels:
@@ -19,7 +19,7 @@ metadata:
     app.kubernetes.io/name: {{ .Values.webhooks.name }}
     {{- include "keda.labels" . | indent 4 }}
     {{- with .Values.deploymentLabels.webhooks }}
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.webhooks.revisionHistoryLimit}}

--- a/keda/templates/webhooks/deployment.yaml
+++ b/keda/templates/webhooks/deployment.yaml
@@ -4,15 +4,23 @@ kind: Deployment
 metadata:
   name: {{ .Values.webhooks.name }}
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.additionalAnnotations }}
+  {{- if or .Values.additionalAnnotations .Values.deploymentAnnotations.webhooks }}
   annotations:
+    {{- with .Values.additionalAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.deploymentAnnotations.webhooks }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
   labels:
     app: {{ .Values.webhooks.name }}
     name: {{ .Values.webhooks.name }}
     app.kubernetes.io/name: {{ .Values.webhooks.name }}
     {{- include "keda.labels" . | indent 4 }}
+    {{- with .Values.deploymentLabels.webhooks }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   revisionHistoryLimit: {{ .Values.webhooks.revisionHistoryLimit}}
   replicas: {{ .Values.webhooks.replicaCount}}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -319,19 +319,23 @@ podLabels:
   metricsAdapter: {}
   # -- Pod labels for KEDA Admission webhooks
   webhooks: {}
+# Values here are rendered through `tpl`, so `{{ ... }}` is evaluated as a template.
+# Escape it as `{{ "{{" }} ... }}` if you need a literal.
 deploymentAnnotations:
-  # -- Deployment annotations for KEDA operator
+  # -- Deployment annotations for KEDA operator. Rendered through `tpl`
   keda: {}
-  # -- Deployment annotations for KEDA Metrics Adapter
+  # -- Deployment annotations for KEDA Metrics Adapter. Rendered through `tpl`
   metricsAdapter: {}
-  # -- Deployment annotations for KEDA Admission webhooks
+  # -- Deployment annotations for KEDA Admission webhooks. Rendered through `tpl`
   webhooks: {}
+# Values here are rendered through `tpl`, so `{{ ... }}` is evaluated as a template.
+# Escape it as `{{ "{{" }} ... }}` if you need a literal.
 deploymentLabels:
-  # -- Deployment labels for KEDA operator
+  # -- Deployment labels for KEDA operator. Rendered through `tpl`
   keda: {}
-  # -- Deployment labels for KEDA Metrics Adapter
+  # -- Deployment labels for KEDA Metrics Adapter. Rendered through `tpl`
   metricsAdapter: {}
-  # -- Deployment labels for KEDA Admission webhooks
+  # -- Deployment labels for KEDA Admission webhooks. Rendered through `tpl`
   webhooks: {}
 
 rbac:

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -319,6 +319,20 @@ podLabels:
   metricsAdapter: {}
   # -- Pod labels for KEDA Admission webhooks
   webhooks: {}
+deploymentAnnotations:
+  # -- Deployment annotations for KEDA operator
+  keda: {}
+  # -- Deployment annotations for KEDA Metrics Adapter
+  metricsAdapter: {}
+  # -- Deployment annotations for KEDA Admission webhooks
+  webhooks: {}
+deploymentLabels:
+  # -- Deployment labels for KEDA operator
+  keda: {}
+  # -- Deployment labels for KEDA Metrics Adapter
+  metricsAdapter: {}
+  # -- Deployment labels for KEDA Admission webhooks
+  webhooks: {}
 
 rbac:
   # -- Specifies whether RBAC should be used


### PR DESCRIPTION
### What

Adds top-level `deploymentLabels` and `deploymentAnnotations` values, keyed per component (`keda` / `metricsAdapter` / `webhooks`), and wires them into the `metadata.labels` / `metadata.annotations` of the operator, metrics-apiserver and webhooks Deployments.

### Why

Today the only way to set Deployment-level labels/annotations is `additionalLabels` / `additionalAnnotations`, which are shared across every component. There is no way to give a different value per component. The use case in #418 is Datadog unified service tagging, where each Deployment needs a distinct `service` (`operator` / `metrics-apiserver` / `webhook`).

This mirrors the existing per-component `podLabels` / `podAnnotations` interface exactly, so the shape is already familiar:

```yaml
deploymentAnnotations:
  keda:
    ad.datadoghq.com/tags: '{"service":"operator"}'
  metricsAdapter:
    ad.datadoghq.com/tags: '{"service":"metrics-apiserver"}'
  webhooks:
    ad.datadoghq.com/tags: '{"service":"webhook"}'
deploymentLabels:
  keda:
    team: platform
```

When set alongside `additionalAnnotations`, both are merged onto the Deployment.

### A note on the approach

In #418 you raised the question of whether to follow the existing `podLabels`/`podAnnotations` map style or move toward a `{component}.foo.bar` nested style. I went with the existing top-level map style here for consistency with `podLabels`/`podAnnotations` and to keep the diff small. Happy to refactor to the per-component nested style if that is the direction you prefer.

### Validation (local)

- `helm lint keda` passes.
- Default render is byte-identical to `main` (new keys default to `{}`, so existing installs see no change).
- `helm template` with the values above merges `additionalAnnotations` + per-component `deploymentAnnotations`, and appends per-component `deploymentLabels`, on all three Deployments.
- Installed on a kind v1.34 cluster: all three Deployments carry the expected per-component `metadata.labels` / `metadata.annotations` on the live specs, and all pods reach Running.
- `keda/Chart.yaml` version intentionally not bumped, per CONTRIBUTING (chart versions are released with KEDA core).

Resolves #418
