### PR TITLE
keda: operator requires core events for leader election

### DIFF
--- a/keda/templates/manager/clusterrole.yaml
+++ b/keda/templates/manager/clusterrole.yaml
@@ -34,6 +34,7 @@ rules:
 {{- end }}
 - apiGroups:
   - events.k8s.io
+  - ""
   resources:
   - events
   verbs:


### PR DESCRIPTION
controller-runtime leader election still emits core events. The RBAC was removed in https://github.com/kedacore/keda/pull/7781 and https://github.com/kedacore/charts/pull/858 with good faith since the event recorder was migrated to use the new `events.k8s.io` API, however, internal dependencies were not searched.

Adding the RBAC back.

closes: https://github.com/kedacore/charts/issues/883