### PR TITLE
feat(http-add-on): rename TLS policy env vars to drop PROXY prefix

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -197,14 +197,14 @@ their default values.
 | `interceptor.tls.appProtocol` | string | `""` | The appProtocol for the interceptor's TLS proxy service port |
 | `interceptor.tls.certPath` | string | `"/certs/tls.crt"` | Mount path of the certificate file to use with the interceptor proxy TLS server. Also accepts the deprecated `cert_path`. |
 | `interceptor.tls.certSecret` | string | `"keda-tls-certs"` | Name of the Kubernetes secret that contains the certificates to be used with the interceptor proxy TLS server. Also accepts the deprecated `cert_secret`. |
-| `interceptor.tls.cipherSuites` | string | `""` | Comma-separated list of supported cipher suites for the interceptor proxy TLS server. Defaults to Go's standard cipher suites. |
-| `interceptor.tls.curvePreferences` | string | `""` | Comma-separated list of supported curve preferences for the interceptor proxy TLS server. Defaults to Go's standard curve selections. |
+| `interceptor.tls.cipherSuites` | string | `""` | Comma-separated list of supported TLS cipher suites. Defaults to Go's standard cipher suites. |
+| `interceptor.tls.curvePreferences` | string | `""` | Comma-separated list of supported TLS curve preferences. Defaults to Go's standard curve selections. |
 | `interceptor.tls.enabled` | bool | `false` | Whether a TLS server should be started on the interceptor proxy |
 | `interceptor.tls.keyPath` | string | `"/certs/tls.key"` | Mount path of the certificate key file to use with the interceptor proxy TLS server. Also accepts the deprecated `key_path`. |
-| `interceptor.tls.maxVersion` | string | `""` | Maximum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard maximum version. |
-| `interceptor.tls.minVersion` | string | `""` | Minimum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard minimum version. |
+| `interceptor.tls.maxVersion` | string | `""` | Maximum TLS version (e.g. "1.2" or "1.3"). Defaults to Go's standard maximum version. |
+| `interceptor.tls.minVersion` | string | `""` | Minimum TLS version (e.g. "1.2" or "1.3"). Defaults to Go's standard minimum version. |
 | `interceptor.tls.port` | int | `8443` | Port that the interceptor proxy TLS server should be started on |
-| `interceptor.tls.skipVerify` | bool | `false` | Whether to skip TLS verification for the interceptor proxy TLS server. Also accepts the deprecated `skip_verify`. |
+| `interceptor.tls.skipVerify` | bool | `false` | Whether to skip TLS certificate verification for upstream connections. Also accepts the deprecated `skip_verify`. |
 | `interceptor.tolerations` | list | `[]` | Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)) |
 | `interceptor.topologySpreadConstraints` | list | `[]` | Topology spread constraints ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)) |
 

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -86,22 +86,22 @@ spec:
           value: "{{ if hasKey .Values.interceptor.tls "key_path" }}{{ .Values.interceptor.tls.key_path }}{{ else }}{{ .Values.interceptor.tls.keyPath }}{{ end }}"
         - name: KEDA_HTTP_PROXY_TLS_PORT
           value: "{{ .Values.interceptor.tls.port }}"
-        - name: KEDA_HTTP_PROXY_TLS_SKIP_VERIFY
+        - name: KEDA_HTTP_TLS_SKIP_VERIFY
           value: "{{ if hasKey .Values.interceptor.tls "skip_verify" }}{{ .Values.interceptor.tls.skip_verify }}{{ else }}{{ .Values.interceptor.tls.skipVerify }}{{ end }}"
         {{- if .Values.interceptor.tls.minVersion }}
-        - name: KEDA_HTTP_PROXY_TLS_MIN_VERSION
+        - name: KEDA_HTTP_TLS_MIN_VERSION
           value: "{{ .Values.interceptor.tls.minVersion }}"
         {{- end }}
         {{- if .Values.interceptor.tls.maxVersion }}
-        - name: KEDA_HTTP_PROXY_TLS_MAX_VERSION
+        - name: KEDA_HTTP_TLS_MAX_VERSION
           value: "{{ .Values.interceptor.tls.maxVersion }}"
         {{- end }}
         {{- if .Values.interceptor.tls.cipherSuites }}
-        - name: KEDA_HTTP_PROXY_TLS_CIPHER_SUITES
+        - name: KEDA_HTTP_TLS_CIPHER_SUITES
           value: "{{ .Values.interceptor.tls.cipherSuites }}"
         {{- end }}
         {{- if .Values.interceptor.tls.curvePreferences }}
-        - name: KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES
+        - name: KEDA_HTTP_TLS_CURVE_PREFERENCES
           value: "{{ .Values.interceptor.tls.curvePreferences }}"
         {{- end }}
         {{- end }}

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -234,15 +234,15 @@ interceptor:
     port: 8443
     # -- The appProtocol for the interceptor's TLS proxy service port
     appProtocol: ""
-    # -- Whether to skip TLS verification for the interceptor proxy TLS server. Also accepts the deprecated `skip_verify`.
+    # -- Whether to skip TLS certificate verification for upstream connections. Also accepts the deprecated `skip_verify`.
     skipVerify: false
-    # -- Minimum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard minimum version.
+    # -- Minimum TLS version (e.g. "1.2" or "1.3"). Defaults to Go's standard minimum version.
     minVersion: ""
-    # -- Maximum TLS version for the interceptor proxy TLS server (e.g. "1.2" or "1.3"). Defaults to Go's standard maximum version.
+    # -- Maximum TLS version (e.g. "1.2" or "1.3"). Defaults to Go's standard maximum version.
     maxVersion: ""
-    # -- Comma-separated list of supported cipher suites for the interceptor proxy TLS server. Defaults to Go's standard cipher suites.
+    # -- Comma-separated list of supported TLS cipher suites. Defaults to Go's standard cipher suites.
     cipherSuites: ""
-    # -- Comma-separated list of supported curve preferences for the interceptor proxy TLS server. Defaults to Go's standard curve selections.
+    # -- Comma-separated list of supported TLS curve preferences. Defaults to Go's standard curve selections.
     curvePreferences: ""
 
   # configuration of pdb for the interceptor


### PR DESCRIPTION
The http-add-on codebase renamed shared TLS policy env vars from KEDA_HTTP_PROXY_TLS_* to KEDA_HTTP_TLS_* since they apply beyond just the proxy listener. The old names still work as deprecated fallbacks in the binary.

### Changes
- Rename 5 interceptor env vars (SKIP_VERIFY, MIN_VERSION, MAX_VERSION, CIPHER_SUITES, CURVE_PREFERENCES)
- Update values.yaml comments to reflect shared TLS policy scope
- Per-listener vars (ENABLED, CERT_PATH, KEY_PATH, PORT) unchanged

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Relates to https://github.com/kedacore/http-add-on/pull/1719
