### PR TITLE
feat(keda): add azureServicePrincipal to TriggerAuthentication CRDs

### DIFF
--- a/keda/templates/crds/crd-clustertriggerauthentications.yaml
+++ b/keda/templates/crds/crd-clustertriggerauthentications.yaml
@@ -325,6 +325,96 @@ spec:
                 - secrets
                 - vaultUri
                 type: object
+              azureServicePrincipal:
+                description: |-
+                  AzureServicePrincipal defines Microsoft Entra service principal credentials
+                  that can be shared by Azure scalers.
+                properties:
+                  activeDirectoryEndpoint:
+                    description: ActiveDirectoryEndpoint is required when cloud is
+                      set to Private.
+                    type: string
+                  clientCertificate:
+                    description: |-
+                      AzureServicePrincipalCredential references credential data stored in a
+                      Kubernetes Secret.
+                    properties:
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                    required:
+                    - valueFrom
+                    type: object
+                  clientCertificatePassword:
+                    description: |-
+                      AzureServicePrincipalCredential references credential data stored in a
+                      Kubernetes Secret.
+                    properties:
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                    required:
+                    - valueFrom
+                    type: object
+                  clientId:
+                    type: string
+                  clientSecret:
+                    description: |-
+                      AzureServicePrincipalCredential references credential data stored in a
+                      Kubernetes Secret.
+                    properties:
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                    required:
+                    - valueFrom
+                    type: object
+                  cloud:
+                    description: Cloud specifies the Azure cloud environment. Defaults
+                      to AzurePublicCloud.
+                    type: string
+                  tenantId:
+                    type: string
+                required:
+                - clientId
+                - tenantId
+                type: object
               boundServiceAccountToken:
                 items:
                   properties:

--- a/keda/templates/crds/crd-triggerauthentications.yaml
+++ b/keda/templates/crds/crd-triggerauthentications.yaml
@@ -321,6 +321,96 @@ spec:
                 - secrets
                 - vaultUri
                 type: object
+              azureServicePrincipal:
+                description: |-
+                  AzureServicePrincipal defines Microsoft Entra service principal credentials
+                  that can be shared by Azure scalers.
+                properties:
+                  activeDirectoryEndpoint:
+                    description: ActiveDirectoryEndpoint is required when cloud is
+                      set to Private.
+                    type: string
+                  clientCertificate:
+                    description: |-
+                      AzureServicePrincipalCredential references credential data stored in a
+                      Kubernetes Secret.
+                    properties:
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                    required:
+                    - valueFrom
+                    type: object
+                  clientCertificatePassword:
+                    description: |-
+                      AzureServicePrincipalCredential references credential data stored in a
+                      Kubernetes Secret.
+                    properties:
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                    required:
+                    - valueFrom
+                    type: object
+                  clientId:
+                    type: string
+                  clientSecret:
+                    description: |-
+                      AzureServicePrincipalCredential references credential data stored in a
+                      Kubernetes Secret.
+                    properties:
+                      valueFrom:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                    required:
+                    - valueFrom
+                    type: object
+                  cloud:
+                    description: Cloud specifies the Azure cloud environment. Defaults
+                      to AzurePublicCloud.
+                    type: string
+                  tenantId:
+                    type: string
+                required:
+                - clientId
+                - tenantId
+                type: object
               boundServiceAccountToken:
                 items:
                   properties:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

Syncs the new `azureServicePrincipal` authentication provider field into the bundled
KEDA CRDs so Helm-based installs recognize the new `TriggerAuthentication` /
`ClusterTriggerAuthentication` spec introduced in KEDA 2.21.

Matches the CRD changes in [kedacore/keda#7931](https://github.com/kedacore/keda/pull/7931).

**Changes**
- `keda/templates/crds/crd-triggerauthentications.yaml` — add the
  `azureServicePrincipal` block (`tenantId`, `clientId`, `cloud`,
  `activeDirectoryEndpoint`, `clientSecret`, `clientCertificate`,
  `clientCertificatePassword`).
- `keda/templates/crds/crd-clustertriggerauthentications.yaml` — same block.

The blocks are byte-identical to the controller-gen output in kedacore/keda
(controller-gen v0.21.0) and inserted alphabetically between `azureKeyVault` and
`boundServiceAccountToken`.

**Validation**
- `helm template keda ./keda --set crds.install=true` renders cleanly (no errors).
- `azureServicePrincipal` present in both rendered CRDs; full manifest parses as valid YAML.
- Rendered schema: `required: [clientId, tenantId]`.

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Relates to kedacore/keda#7931
Relates to kedacore/keda-docs#1814

