### PR TITLE
docs: fix release index step overwriting `created` timestamps (#877)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,7 @@ You can easily release a new Helm chart version:
     $ rm -rf /tmp/new-release
     ```
 
-    ⚠️ Do NOT run `helm repo index docs` directly — this rescans every
-    historical .tgz in docs/ and overwrites their original `created`
-    timestamp with the current time (see issue [#877](https://github.com/kedacore/charts/issues/877)). Instead, isolate
-    the newly packaged chart(s) and merge against the existing index,
-    so only the new entry gets a fresh `created` and every other
-    entry keeps its original release timestamp:
+    Running `helm repo index docs` directly rescans every historical .tgz in docs/ and overwrites their original `created` timestamp with the current time (see issue [#877](https://github.com/kedacore/charts/issues/877)).
 
 7. Update the version in the "Browse all our Helm charts" section of our README.md
 8. Commit changes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,20 @@ You can easily release a new Helm chart version:
         ```
 6. Re-index the Helm repo to add our new version:
     ```shell
-    $ helm repo index docs --url https://kedacore.github.io/charts
+    $ mkdir /tmp/new-release
+    $ cp docs/keda-x.y.z.tgz /tmp/new-release/
+    $ helm repo index /tmp/new-release --url https://kedacore.github.io/charts --merge docs/index.yaml
+    $ cp /tmp/new-release/index.yaml docs/index.yaml
+    $ rm -rf /tmp/new-release
     ```
+
+    ⚠️ Do NOT run `helm repo index docs` directly — this rescans every
+    historical .tgz in docs/ and overwrites their original `created`
+    timestamp with the current time (see issue [#877](https://github.com/kedacore/charts/issues/877)). Instead, isolate
+    the newly packaged chart(s) and merge against the existing index,
+    so only the new entry gets a fresh `created` and every other
+    entry keeps its original release timestamp:
+
 7. Update the version in the "Browse all our Helm charts" section of our README.md
 8. Commit changes:
     ```shell


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)

## Description

Fixes the release step in CONTRIBUTING.md that regenerates
`docs/index.yaml` on every chart release.

`helm repo index docs --url ...` scans the entire `docs/` folder —
which contains every historical `.tgz` ever published — and stamps
`created: <now>` on all of them, not just the newly packaged
version. As a result:

- Every chart's `created` reflects the last index rebuild, not its
  actual publish date.
- A release of any single chart (e.g. `keda-add-ons-http`) resets
  the `created` timestamp of every other chart's versions too
  (e.g. `keda`), even though they didn't change.
- This breaks tooling that gates on release age, such as Renovate's
  `minimumReleaseAge`: an already-"aged" version has its clock
  reset to zero on every unrelated release.

## Fix

Instead of indexing `docs/` directly, isolate only the newly
packaged chart(s) in a temporary directory and index that directory
with `--merge` pointed at the existing `docs/index.yaml`. Helm's
`--merge` preserves `created` for any entry it doesn't find in the
scanned directory, so previously published versions keep their
original timestamp and only the new release gets a fresh one.

```bash
mkdir /tmp/new-release
cp docs/keda-x.y.z.tgz /tmp/new-release/
helm repo index /tmp/new-release --url https://kedacore.github.io/charts --merge docs/index.yaml
cp /tmp/new-release/index.yaml docs/index.yaml
rm -rf /tmp/new-release
```

## Validation

Tested locally against the current published `docs/index.yaml`
(105 entries). Indexing a single new package this way changed
exactly 1 `created` entry (the new release) and left the other 104
untouched,

## Notes for reviewers

- Behavior only changes for the index-generation step; the
  published repo structure (`docs/*.tgz`, `docs/index.yaml` at the
  same URL) is unchanged.

Fixes #877 