### PR TITLE
feat(http-add-on): add custom CA trust and extra volumes support

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -170,6 +170,8 @@ their default values.
 | `interceptor.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
 | `interceptor.drainTimeout` | string | `"30s"` | Maximum time to wait for in-flight requests (including WebSocket connections) to complete after the proxy listener closes. `0` waits indefinitely (bounded only by terminationGracePeriodSeconds). |
 | `interceptor.extraEnvs` | object | `{}` | Extra environment variables to set (key-value map with "ENV name":"value") |
+| `interceptor.extraVolumeMounts` | list | `[]` | Extra volume mounts for the interceptor container |
+| `interceptor.extraVolumes` | list | `[]` | Extra volumes for the interceptor pod |
 | `interceptor.imagePullSecrets` | list | `[]` | The image pull secrets for the interceptor component |
 | `interceptor.maxIdleConns` | int | `1000` | The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit |
 | `interceptor.maxIdleConnsPerHost` | int | `200` | The maximum number of idle connections allowed per host in the interceptor's in-memory connection pool |
@@ -195,6 +197,7 @@ their default values.
 | `interceptor.tcpConnectTimeout` | string | `""` | Per-attempt TCP dial timeout. When unset, uses the code default (500ms). |
 | `interceptor.terminationGracePeriodSeconds` | int | `45` | Time Kubernetes waits before sending SIGKILL after SIGTERM. Must be at least shutdownDelay + drainTimeout. |
 | `interceptor.tls.appProtocol` | string | `""` | The appProtocol for the interceptor's TLS proxy service port |
+| `interceptor.tls.caDirs` | list | `[]` | List of directories containing PEM CA certificates to trust for outbound backend connections, in addition to the system CA pool. |
 | `interceptor.tls.certPath` | string | `"/certs/tls.crt"` | Mount path of the certificate file to use with the interceptor proxy TLS server. Also accepts the deprecated `cert_path`. |
 | `interceptor.tls.certSecret` | string | `"keda-tls-certs"` | Name of the Kubernetes secret that contains the certificates to be used with the interceptor proxy TLS server. Also accepts the deprecated `cert_secret`. |
 | `interceptor.tls.cipherSuites` | string | `""` | Comma-separated list of supported TLS cipher suites. Defaults to Go's standard cipher suites. |

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -86,15 +86,10 @@ spec:
           value: "{{ if hasKey .Values.interceptor.tls "key_path" }}{{ .Values.interceptor.tls.key_path }}{{ else }}{{ .Values.interceptor.tls.keyPath }}{{ end }}"
         - name: KEDA_HTTP_PROXY_TLS_PORT
           value: "{{ .Values.interceptor.tls.port }}"
-        - name: KEDA_HTTP_TLS_SKIP_VERIFY
-          value: "{{ if hasKey .Values.interceptor.tls "skip_verify" }}{{ .Values.interceptor.tls.skip_verify }}{{ else }}{{ .Values.interceptor.tls.skipVerify }}{{ end }}"
-        {{- if .Values.interceptor.tls.minVersion }}
-        - name: KEDA_HTTP_TLS_MIN_VERSION
-          value: "{{ .Values.interceptor.tls.minVersion }}"
         {{- end }}
-        {{- if .Values.interceptor.tls.maxVersion }}
-        - name: KEDA_HTTP_TLS_MAX_VERSION
-          value: "{{ .Values.interceptor.tls.maxVersion }}"
+        {{- if .Values.interceptor.tls.caDirs }}
+        - name: KEDA_HTTP_TLS_CA_DIRS
+          value: "{{ join "," .Values.interceptor.tls.caDirs }}"
         {{- end }}
         {{- if .Values.interceptor.tls.cipherSuites }}
         - name: KEDA_HTTP_TLS_CIPHER_SUITES
@@ -104,7 +99,16 @@ spec:
         - name: KEDA_HTTP_TLS_CURVE_PREFERENCES
           value: "{{ .Values.interceptor.tls.curvePreferences }}"
         {{- end }}
+        {{- if .Values.interceptor.tls.maxVersion }}
+        - name: KEDA_HTTP_TLS_MAX_VERSION
+          value: "{{ .Values.interceptor.tls.maxVersion }}"
         {{- end }}
+        {{- if .Values.interceptor.tls.minVersion }}
+        - name: KEDA_HTTP_TLS_MIN_VERSION
+          value: "{{ .Values.interceptor.tls.minVersion }}"
+        {{- end }}
+        - name: KEDA_HTTP_TLS_SKIP_VERIFY
+          value: "{{ if hasKey .Values.interceptor.tls "skip_verify" }}{{ .Values.interceptor.tls.skip_verify }}{{ else }}{{ .Values.interceptor.tls.skipVerify }}{{ end }}"
         {{- if .Values.profiling.interceptor.enabled }}
         - name: PROFILING_BIND_ADDRESS
           value: "127.0.0.1:{{ .Values.profiling.interceptor.port }}"
@@ -121,10 +125,17 @@ spec:
         {{- if .Values.interceptor.tls.enabled }}
         - containerPort: {{ .Values.interceptor.tls.port }}
           name: proxy-tls
+        {{- end }}
+        {{- if or .Values.interceptor.tls.enabled .Values.interceptor.extraVolumeMounts }}
         volumeMounts:
+        {{- if .Values.interceptor.tls.enabled }}
           - readOnly: true
             mountPath: "/certs"
             name: certs
+        {{- end }}
+        {{- with .Values.interceptor.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- end }}
         livenessProbe:
           httpGet:
@@ -144,11 +155,16 @@ spec:
         {{- toYaml .Values.securityContext | nindent 10 }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.interceptor.terminationGracePeriodSeconds }}
-      {{- if .Values.interceptor.tls.enabled }}
+      {{- if or .Values.interceptor.tls.enabled .Values.interceptor.extraVolumes }}
       volumes:
+      {{- if .Values.interceptor.tls.enabled }}
         - name: certs
           secret:
             secretName: {{ if hasKey .Values.interceptor.tls "cert_secret" }}{{ .Values.interceptor.tls.cert_secret }}{{ else }}{{ .Values.interceptor.tls.certSecret }}{{ end }}
+      {{- end }}
+      {{- with .Values.interceptor.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       nodeSelector:
         kubernetes.io/os: linux

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -143,6 +143,10 @@ scaler:
 interceptor:
   # -- Extra environment variables to set (key-value map with "ENV name":"value")
   extraEnvs: {}
+  # -- Extra volume mounts for the interceptor container
+  extraVolumeMounts: []
+  # -- Extra volumes for the interceptor pod
+  extraVolumes: []
   # -- The image pull secrets for the interceptor component
   imagePullSecrets: []
   # -- The image pull policy for the interceptor component
@@ -244,6 +248,8 @@ interceptor:
     cipherSuites: ""
     # -- Comma-separated list of supported TLS curve preferences. Defaults to Go's standard curve selections.
     curvePreferences: ""
+    # -- List of directories containing PEM CA certificates to trust for outbound backend connections, in addition to the system CA pool.
+    caDirs: []
 
   # configuration of pdb for the interceptor
   pdb:


### PR DESCRIPTION
The interceptor had no way to trust custom CAs for outbound backend connections. This adds the caDirs Helm value and extraVolumes/ extraVolumeMounts support to mount CA bundles.

### Changes
- Add interceptor.tls.caDirs for KEDA_HTTP_TLS_CA_DIRS
- Add interceptor.extraVolumes and interceptor.extraVolumeMounts
- Move outbound TLS policy env vars outside tls.enabled block so they apply independently of serving TLS


### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)


Relates to https://github.com/kedacore/http-add-on/pull/1731