### PR TITLE
feat(http-add-on): add interceptor.directPodRouting Helm value

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -169,6 +169,7 @@ their default values.
 | `interceptor.admin.service` | string | `"interceptor-admin"` | The name of the Kubernetes `Service` for the interceptor's admin service |
 | `interceptor.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
 | `interceptor.drainTimeout` | string | `"30s"` | Maximum time to wait for in-flight requests (including WebSocket connections) to complete after the proxy listener closes. `0` waits indefinitely (bounded only by terminationGracePeriodSeconds). |
+| `interceptor.directPodRouting` | bool | `true` | Route requests directly to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features (NetworkPolicy, session affinity, topology-aware routing). Set to false to keep Service-based routing. |
 | `interceptor.extraEnvs` | object | `{}` | Extra environment variables to set (key-value map with "ENV name":"value") |
 | `interceptor.imagePullSecrets` | list | `[]` | The image pull secrets for the interceptor component |
 | `interceptor.maxIdleConns` | int | `1000` | The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit |

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -73,6 +73,8 @@ spec:
           value: "{{ .Values.interceptor.maxIdleConns }}"
         - name: KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST
           value: "{{ .Values.interceptor.maxIdleConnsPerHost }}"
+        - name: KEDA_HTTP_DIRECT_POD_ROUTING
+          value: "{{ .Values.interceptor.directPodRouting }}"
         - name: KEDA_HTTP_SHUTDOWN_DELAY
           value: "{{ .Values.interceptor.shutdownDelay }}"
         - name: KEDA_HTTP_DRAIN_TIMEOUT

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -200,6 +200,8 @@ interceptor:
   maxIdleConns: 1000
   # -- The maximum number of idle connections allowed per host in the interceptor's in-memory connection pool
   maxIdleConnsPerHost: 200
+  # -- Route requests directly to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features (NetworkPolicy, session affinity, topology-aware routing). Set to false to keep Service-based routing.
+  directPodRouting: true
   # -- Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/))
   nodeSelector: {}
   # -- Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/))


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md
-->

Add `interceptor.directPodRouting` (default `true`) to expose `KEDA_HTTP_DIRECT_POD_ROUTING` on the interceptor deployment.

When enabled, the interceptor routes requests directly to a ready pod IP instead of the Service ClusterIP. Operators who need Service-layer features (NetworkPolicy, session affinity, topology-aware routing) can set it to `false`.

Matches the upstream default from kedacore/http-add-on#1697 / [#1473](https://github.com/kedacore/http-add-on/issues/1473).

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Relates to https://github.com/kedacore/http-add-on/issues/1473