### PR TITLE
Add HTTP transport connection pool settings

### DIFF
--- a/keda/README.md
+++ b/keda/README.md
@@ -90,10 +90,10 @@ their default values.
 | `grpcTLSCertsSecret` | string | `""` | Set this if you are using an external scaler and want to communicate over TLS (recommended). This variable holds the name of the secret that will be mounted to the /grpccerts path on the Pod |
 | `hashiCorpVaultTLS` | string | `""` | Set this if you are using HashiCorp Vault and want to communicate over TLS (recommended). This variable holds the name of the secret that will be mounted to the /vault path on the Pod |
 | `hostAliases` | list | `[]` | HostAliases for pod networking ([docs](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/)) |
-| `http.idleConnTimeout` | string | `nil` | Maximum time an idle HTTP connection remains in the pool. When unset, the operator default (90s) applies. Must be greater than zero. |
+| `http.idleConnTimeout` | string | `"90s"` | Maximum time an idle HTTP connection remains in the pool. Must be greater than zero. |
 | `http.keepAlive.enabled` | bool | `true` | Enable HTTP connection keep alive |
-| `http.maxIdleConns` | int | `nil` | Maximum number of idle HTTP connections across all hosts. When unset, the operator default (0, no limit) applies. |
-| `http.maxIdleConnsPerHost` | int | `nil` | Maximum number of idle HTTP connections to keep per host. When unset, the operator default (1000) applies. |
+| `http.maxIdleConns` | int | `0` | Maximum number of idle HTTP connections across all hosts. Zero means no limit. |
+| `http.maxIdleConnsPerHost` | int | `1000` | Maximum number of idle HTTP connections to keep per host |
 | `http.minTlsVersion` | string | `"TLS12"` | The minimum TLS version to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and this value does not necessarily apply to them) |
 | `http.tlsCipherList` | string | `""` | The list of cipher suites to use when making HTTP over TLS connections. When left empty or unset, the TLS implementation will provide a default list of cipher suites which are believed to be secure. |
 | `http.timeout` | int | `3000` | The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them) |

--- a/keda/README.md
+++ b/keda/README.md
@@ -90,7 +90,10 @@ their default values.
 | `grpcTLSCertsSecret` | string | `""` | Set this if you are using an external scaler and want to communicate over TLS (recommended). This variable holds the name of the secret that will be mounted to the /grpccerts path on the Pod |
 | `hashiCorpVaultTLS` | string | `""` | Set this if you are using HashiCorp Vault and want to communicate over TLS (recommended). This variable holds the name of the secret that will be mounted to the /vault path on the Pod |
 | `hostAliases` | list | `[]` | HostAliases for pod networking ([docs](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/)) |
+| `http.idleConnTimeout` | string | `nil` | Maximum time an idle HTTP connection remains in the pool. When unset, the operator default (90s) applies. Must be greater than zero. |
 | `http.keepAlive.enabled` | bool | `true` | Enable HTTP connection keep alive |
+| `http.maxIdleConns` | int | `nil` | Maximum number of idle HTTP connections across all hosts. When unset, the operator default (0, no limit) applies. |
+| `http.maxIdleConnsPerHost` | int | `nil` | Maximum number of idle HTTP connections to keep per host. When unset, the operator default (1000) applies. |
 | `http.minTlsVersion` | string | `"TLS12"` | The minimum TLS version to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and this value does not necessarily apply to them) |
 | `http.tlsCipherList` | string | `""` | The list of cipher suites to use when making HTTP over TLS connections. When left empty or unset, the TLS implementation will provide a default list of cipher suites which are believed to be secure. |
 | `http.timeout` | int | `3000` | The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them) |

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -116,15 +116,9 @@ spec:
           - "--ca-dir={{ . }}"
           {{- end }}
           {{- end }}
-          {{- if not (kindIs "invalid" .Values.http.maxIdleConns) }}
           - "--http-max-idle-conns={{ .Values.http.maxIdleConns }}"
-          {{- end }}
-          {{- if not (kindIs "invalid" .Values.http.maxIdleConnsPerHost) }}
           - "--http-max-idle-conns-per-host={{ .Values.http.maxIdleConnsPerHost }}"
-          {{- end }}
-          {{- if not (kindIs "invalid" .Values.http.idleConnTimeout) }}
           - "--http-idle-conn-timeout={{ .Values.http.idleConnTimeout }}"
-          {{- end }}
           {{- range $key, $value := .Values.extraArgs.keda }}
           - "--{{ $key }}={{ $value }}"
           {{- end }}

--- a/keda/templates/manager/deployment.yaml
+++ b/keda/templates/manager/deployment.yaml
@@ -116,6 +116,15 @@ spec:
           - "--ca-dir={{ . }}"
           {{- end }}
           {{- end }}
+          {{- if not (kindIs "invalid" .Values.http.maxIdleConns) }}
+          - "--http-max-idle-conns={{ .Values.http.maxIdleConns }}"
+          {{- end }}
+          {{- if not (kindIs "invalid" .Values.http.maxIdleConnsPerHost) }}
+          - "--http-max-idle-conns-per-host={{ .Values.http.maxIdleConnsPerHost }}"
+          {{- end }}
+          {{- if not (kindIs "invalid" .Values.http.idleConnTimeout) }}
+          - "--http-idle-conn-timeout={{ .Values.http.idleConnTimeout }}"
+          {{- end }}
           {{- range $key, $value := .Values.extraArgs.keda }}
           - "--{{ $key }}={{ $value }}"
           {{- end }}

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -607,6 +607,12 @@ priorityClassName: ""
 http:
   # -- The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them)
   timeout: 3000
+  # -- Maximum number of idle HTTP connections across all hosts. When unset, the operator default (0, no limit) applies.
+  maxIdleConns:
+  # -- Maximum number of idle HTTP connections to keep per host. When unset, the operator default (1000) applies.
+  maxIdleConnsPerHost:
+  # -- Maximum time an idle HTTP connection remains in the pool. When unset, the operator default (90s) applies. Must be greater than zero.
+  idleConnTimeout:
   keepAlive:
     # -- Enable HTTP connection keep alive
     enabled: true

--- a/keda/values.yaml
+++ b/keda/values.yaml
@@ -607,12 +607,12 @@ priorityClassName: ""
 http:
   # -- The default HTTP timeout to use for all scalers that use raw HTTP clients (some scalers use SDKs to access target services. These have built-in HTTP clients, and the timeout does not necessarily apply to them)
   timeout: 3000
-  # -- Maximum number of idle HTTP connections across all hosts. When unset, the operator default (0, no limit) applies.
-  maxIdleConns:
-  # -- Maximum number of idle HTTP connections to keep per host. When unset, the operator default (1000) applies.
-  maxIdleConnsPerHost:
-  # -- Maximum time an idle HTTP connection remains in the pool. When unset, the operator default (90s) applies. Must be greater than zero.
-  idleConnTimeout:
+  # -- Maximum number of idle HTTP connections across all hosts. Zero means no limit.
+  maxIdleConns: 0
+  # -- Maximum number of idle HTTP connections to keep per host
+  maxIdleConnsPerHost: 1000
+  # -- Maximum time an idle HTTP connection remains in the pool. Must be greater than zero.
+  idleConnTimeout: 90s
   keepAlive:
     # -- Enable HTTP connection keep alive
     enabled: true


### PR DESCRIPTION
Adds Helm values for configuring the KEDA operator HTTP transport connection pool and passes them through the corresponding operator flags. Defaults match the KEDA binary defaults.

This intentionally leaves the existing `KEDA_HTTP_DISABLE_KEEP_ALIVE` integration unchanged.

### Checklist

- [X] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [X] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [X] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [X] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Fixes #

Relates to kedacore/keda#7789
Relates to kedacore/keda#7941