### PR TITLE
feat(http-add-on): add interceptor.coldStart.maxPendingRequests Helm value

### DIFF
--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -168,6 +168,7 @@ their default values.
 | `interceptor.admin.port` | int | `9090` | The port for the interceptor's admin server to run on |
 | `interceptor.admin.service` | string | `"interceptor-admin"` | The name of the Kubernetes `Service` for the interceptor's admin service |
 | `interceptor.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
+| `interceptor.coldStartMaxPendingRequests` | int | `0` | Default limit on requests held per route while its backend has no ready endpoints, e.g. during scale-from-zero. Routes override it via `coldStart.maxPendingRequests`. 0 means unlimited. The limit applies per interceptor replica. |
 | `interceptor.drainTimeout` | string | `"30s"` | Maximum time to wait for in-flight requests (including WebSocket connections) to complete after the proxy listener closes. `0` waits indefinitely (bounded only by terminationGracePeriodSeconds). |
 | `interceptor.directPodRouting` | bool | `true` | Route requests directly to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features (NetworkPolicy, session affinity, topology-aware routing). Set to false to keep Service-based routing. |
 | `interceptor.extraEnvs` | object | `{}` | Extra environment variables to set (key-value map with "ENV name":"value") |

--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -169,6 +169,7 @@ their default values.
 | `interceptor.admin.service` | string | `"interceptor-admin"` | The name of the Kubernetes `Service` for the interceptor's admin service |
 | `interceptor.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
 | `interceptor.drainTimeout` | string | `"30s"` | Maximum time to wait for in-flight requests (including WebSocket connections) to complete after the proxy listener closes. `0` waits indefinitely (bounded only by terminationGracePeriodSeconds). |
+| `interceptor.directPodRouting` | bool | `true` | Route requests directly to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features (NetworkPolicy, session affinity, topology-aware routing). Set to false to keep Service-based routing. |
 | `interceptor.extraEnvs` | object | `{}` | Extra environment variables to set (key-value map with "ENV name":"value") |
 | `interceptor.imagePullSecrets` | list | `[]` | The image pull secrets for the interceptor component |
 | `interceptor.maxIdleConns` | int | `1000` | The maximum number of idle connections allowed in the interceptor's in-memory connection pool. Set to 0 to indicate no limit |

--- a/http-add-on/README.md
+++ b/http-add-on/README.md
@@ -168,7 +168,7 @@ their default values.
 | `interceptor.admin.port` | int | `9090` | The port for the interceptor's admin server to run on |
 | `interceptor.admin.service` | string | `"interceptor-admin"` | The name of the Kubernetes `Service` for the interceptor's admin service |
 | `interceptor.affinity` | object | `{}` | Affinity for pod scheduling ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)) |
-| `interceptor.coldStartMaxPendingRequests` | int | `0` | Default limit on requests held per route while its backend has no ready endpoints, e.g. during scale-from-zero. Routes override it via `coldStart.maxPendingRequests`. 0 means unlimited. The limit applies per interceptor replica. |
+| `interceptor.coldStart.maxPendingRequests` | int | `0` | Default limit on requests held per route while its backend has no ready endpoints, e.g. during scale-from-zero. Routes override it via `coldStart.maxPendingRequests`. 0 means unlimited. The limit applies per interceptor replica. |
 | `interceptor.drainTimeout` | string | `"30s"` | Maximum time to wait for in-flight requests (including WebSocket connections) to complete after the proxy listener closes. `0` waits indefinitely (bounded only by terminationGracePeriodSeconds). |
 | `interceptor.directPodRouting` | bool | `true` | Route requests directly to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features (NetworkPolicy, session affinity, topology-aware routing). Set to false to keep Service-based routing. |
 | `interceptor.extraEnvs` | object | `{}` | Extra environment variables to set (key-value map with "ENV name":"value") |

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -73,6 +73,8 @@ spec:
           value: "{{ .Values.interceptor.maxIdleConns }}"
         - name: KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST
           value: "{{ .Values.interceptor.maxIdleConnsPerHost }}"
+        - name: KEDA_HTTP_DIRECT_POD_ROUTING
+          value: "{{ .Values.interceptor.directPodRouting }}"
         - name: KEDA_HTTP_SHUTDOWN_DELAY
           value: "{{ .Values.interceptor.shutdownDelay }}"
         - name: KEDA_HTTP_DRAIN_TIMEOUT

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         - name: KEDA_HTTP_DIRECT_POD_ROUTING
           value: "{{ .Values.interceptor.directPodRouting }}"
         - name: KEDA_HTTP_COLD_START_MAX_PENDING_REQUESTS
-          value: "{{ .Values.interceptor.coldStartMaxPendingRequests }}"
+          value: "{{ .Values.interceptor.coldStart.maxPendingRequests }}"
         - name: KEDA_HTTP_SHUTDOWN_DELAY
           value: "{{ .Values.interceptor.shutdownDelay }}"
         - name: KEDA_HTTP_DRAIN_TIMEOUT

--- a/http-add-on/templates/interceptor/deployment.yaml
+++ b/http-add-on/templates/interceptor/deployment.yaml
@@ -75,6 +75,8 @@ spec:
           value: "{{ .Values.interceptor.maxIdleConnsPerHost }}"
         - name: KEDA_HTTP_DIRECT_POD_ROUTING
           value: "{{ .Values.interceptor.directPodRouting }}"
+        - name: KEDA_HTTP_COLD_START_MAX_PENDING_REQUESTS
+          value: "{{ .Values.interceptor.coldStartMaxPendingRequests }}"
         - name: KEDA_HTTP_SHUTDOWN_DELAY
           value: "{{ .Values.interceptor.shutdownDelay }}"
         - name: KEDA_HTTP_DRAIN_TIMEOUT

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -202,6 +202,8 @@ interceptor:
   maxIdleConnsPerHost: 200
   # -- Route requests directly to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features (NetworkPolicy, session affinity, topology-aware routing). Set to false to keep Service-based routing.
   directPodRouting: true
+  # -- Default limit on requests held per route while its backend has no ready endpoints, e.g. during scale-from-zero. Routes override it via coldStart.maxPendingRequests. 0 means unlimited. The limit applies per interceptor replica.
+  coldStartMaxPendingRequests: 0
   # -- Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/))
   nodeSelector: {}
   # -- Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/))

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -202,8 +202,10 @@ interceptor:
   maxIdleConnsPerHost: 200
   # -- Route requests directly to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features (NetworkPolicy, session affinity, topology-aware routing). Set to false to keep Service-based routing.
   directPodRouting: true
-  # -- Default limit on requests held per route while its backend has no ready endpoints, e.g. during scale-from-zero. Routes override it via coldStart.maxPendingRequests. 0 means unlimited. The limit applies per interceptor replica.
-  coldStartMaxPendingRequests: 0
+  # cold start behavior when scaling from zero
+  coldStart:
+    # -- Default limit on requests held per route while its backend has no ready endpoints, e.g. during scale-from-zero. Routes override it via coldStart.maxPendingRequests. 0 means unlimited. The limit applies per interceptor replica.
+    maxPendingRequests: 0
   # -- Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/))
   nodeSelector: {}
   # -- Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/))

--- a/http-add-on/values.yaml
+++ b/http-add-on/values.yaml
@@ -200,6 +200,8 @@ interceptor:
   maxIdleConns: 1000
   # -- The maximum number of idle connections allowed per host in the interceptor's in-memory connection pool
   maxIdleConnsPerHost: 200
+  # -- Route requests directly to a ready pod IP instead of the Service ClusterIP, bypassing kube-proxy and other Service-layer features (NetworkPolicy, session affinity, topology-aware routing). Set to false to keep Service-based routing.
+  directPodRouting: true
   # -- Node selector for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/))
   nodeSelector: {}
   # -- Tolerations for pod scheduling ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/))


### PR DESCRIPTION
Expose `KEDA_HTTP_COLD_START_MAX_PENDING_REQUESTS` as a new `interceptor.coldStart.maxPendingRequests` Helm value, so operators can set a cluster-wide default limit on requests held per route while a backend scales from zero. This protects interceptor pods from memory/FD exhaustion during request bursts against cold apps.

Defaults to `0` (unlimited), preserving current behavior on upgrade. Routes can override it via the `coldStart.maxPendingRequests` InterceptorRoute field.

Depends on kedacore/http-add-on#1733 (feature is approved, not yet merged/released — the env var is a no-op on older interceptor images).

### Checklist

- [x] I have verified that my change is according to the [deprecations & breaking changes policy](https://github.com/kedacore/governance/blob/main/DEPRECATIONS.md)
- [x] Commits are signed with Developer Certificate of Origin (DCO - [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-signing-your-work))
- [x] README is updated with new configuration values *(if applicable)* [learn more](https://github.com/kedacore/charts/blob/main/CONTRIBUTING.md#documentation)
- [x] A PR is opened to update KEDA core ([repo](https://github.com/kedacore/keda)) *(if applicable, ie. when deployment manifests are modified)*

Relates to kedacore/http-add-on#1732