### PR TITLE
fix(http-add-on): grant interceptor RBAC to watch configmaps

### DIFF
--- a/http-add-on/templates/interceptor/rbac.yml
+++ b/http-add-on/templates/interceptor/rbac.yml
@@ -19,6 +19,7 @@ rules:
   - ""
   resources:
   - services
+  - configmaps
   verbs:
   - get
   - list


### PR DESCRIPTION
Small RBAC fix. The interceptor ClusterRole is missing permission to watch configmaps, even though the interceptor code already needs it for the `coldStart` placeholder feature (serving a static response body from a configmap while a backend scales up from zero).

Right now every interceptor pod logs this:


```
configmaps is forbidden: User "system:serviceaccount:<ns>:<release>-interceptor" cannot list resource "configmaps" in API group "" at the cluster scope
```

and just silently falls back to the old hold-and-wait behavior instead of using the placeholder response.

This permission already exists in `kedacore/http-add-on`'s own kustomize manifests (`config/interceptor/role.yaml`), added in   [#1626](https://github.com/kedacore/http-add-on/pull/1626/changes#diff-84b7cd37cbd949d7d47aea3def3697957d64524e34225c312cb82f54c8d96d29) when `coldStart.placeholder` support was added. It just never made it into this chart's helm template.